### PR TITLE
Support ST4 42XX C# syntax rewrite

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Exclude .sublime-project files from export
+*.sublime-project export-ignore
+
+# Exclude everything in the tests directory from export
+tests/** export-ignore

--- a/Comments (Razor).tmPreferences
+++ b/Comments (Razor).tmPreferences
@@ -5,7 +5,7 @@
 		<key>name</key>
 		<string>Comments</string>
 		<key>scope</key>
-		<string>source.razor,embed.text.html</string>
+		<string>source.razor,embed.text.html.razor</string>
 		<key>settings</key>
 		<dict>
 			<key>shellVariables</key>

--- a/syntax/Razor C# (CSS).sublime-syntax
+++ b/syntax/Razor C# (CSS).sublime-syntax
@@ -1,0 +1,37 @@
+%YAML 1.2
+---
+name: Razor C# (CSS)
+scope: embed.text.css.razor
+version: 2
+hidden: true
+
+extends: Packages/CSS/CSS.sublime-syntax
+
+#############################
+
+contexts:
+
+  prototype:
+    - meta_prepend: true
+    - include: razor-comments
+
+  main:
+    - include: stylesheet
+
+  razor-comments:
+    # E-mail addresses have the @ symbol but don't activate code.
+    - match: '[\+-.\w]+@[-a-z0-9]+(\.[-a-z0-9]+)*'
+      scope: meta.email
+    # Match an escaped @.
+    - match: '@@'
+      scope: constant.character.escape
+    # Match the start of our comment.
+    - match: '@\*'
+      scope: punctuation.definition.comment.begin.razor
+      push:
+        - meta_scope: comment.block.razor
+        - match: '\*@'
+          scope: punctuation.definition.comment.end.razor
+          pop: 1
+    - match: '\*@'
+      scope: invalid.illegal.stray-comment-end.razor

--- a/syntax/Razor C# (CSharp).sublime-syntax
+++ b/syntax/Razor C# (CSharp).sublime-syntax
@@ -2,6 +2,7 @@
 ---
 name: Razor C# (CSharp)
 scope: embed.source.cs.razor
+version: 2
 hidden: true
 
 extends: Packages/C#/C#.sublime-syntax
@@ -34,18 +35,89 @@ contexts:
 
   # Used for @typeparam since it allows where constraints on the generic type.
   # Embed target with an end-of-line escape.
-  razor_type_with_constraint:
+  razor-type-with-constraint:
     - match: '{{name}}'
       scope: entity.name.interface.cs
-      set: [data_type_constraint, data_type_parameter]
+      set: type-constraints
 
-  code_block_in:
+  # A single statement that actually ends.
+  razor-statement-eol:
+    - match: '(?=<)'
+      pop: 1
+    - match: '$\n?'
+      pop: 1
+    - include: inside-statement-block
+
+  # Variant of expression that pops on HTML or newlines.
+  razor-expression-eol:
+    - match: '(?=<)'
+      pop: 1
+    - match: '$\n?'
+      pop: 1
+    - include: parens
+    - include: lambdas
+    - match: '{{name}}(?={{generic_declaration}}\s*\.)'
+      scope: support.type.cs
+      pop: 1
+    - include: expression-common
+    - include: else-pop
+
+  # Variant of expression that handles just an expression and pops on ) or newlines.
+  razor-expression-paren:
+    - include: razor-comments
+    - match: '\)'
+      scope: keyword.other.inline.end.razor
+      pop: 1
+    - match: '$\n?'
+      pop: 1
+    - include: expression
+
+  # Variant of expression that pops on string end or newlines.
+  # Used for data binding in Razor components.
+  razor-single-quote-expression:
+    - include: razor-comments
+    - match: "(?=')"
+      scope: string.quoted.single.html punctuation.definition.string.end.html
+      pop: 1
+    - match: '$\n?'
+      pop: 1
+    - include: expression
+  razor-double-quote-expression:
+    - include: razor-comments
+    - match: '(?=\")'
+      scope: string.quoted.double.html punctuation.definition.string.end.html
+      pop: 1
+    - match: '$\n?'
+      pop: 1
+    - include: expression
+
+  # Allows proper formatting on the final closing brace.
+  inside-razor-csharp-block:
     - meta_prepend: true
     - meta_scope: meta.block.cs
     # Pop at the end of the block so we transition back to HTML correctly.
     - match: '\}'
       scope: keyword.other.block.razor punctuation.block.end.razor
       pop: 1
+    - include: inside-csharp-block
+
+###[ C# OVERRIDES ]############################################################
+
+  # Allows HTML context switching and Razor comments.
+  expression:
+    - meta_prepend: true
+    - match: '\@(?=<)'
+      scope: keyword.other.embed.html.razor
+      push: scope:source.razor#tag-html-embed
+
+  expression-common:
+    - meta_prepend: true
+    - match: '(?=<)'
+      pop: 1
+
+  inside-csharp-block:
+    - meta_prepend: true
+    - meta_scope: meta.block.cs
     # Support <text></text>.
     - match: '(<)(text)(>)'
       captures:
@@ -67,69 +139,10 @@ contexts:
       embed: scope:source.razor
       escape: '$\n?'
 
-  # Allows HTML context switching and Razor comments.
-  line_of_code_in:
+  # Enables use of templated Razor delegates.
+  assignment-value:
     - meta_prepend: true
+    - include: razor-comments
     - match: '\@(?=<)'
       scope: keyword.other.embed.html.razor
-      push: scope:source.razor#tag-html-embed
-
-  # Variant of line_of_code_in that pops on HTML or newlines.
-  razor_line_of_code_in:
-    - meta_prepend: true
-    - match: '(?=<)'
-      pop: 1
-    - match: '$\n?'
-      pop: 1
-    - include: line_of_code_in
-
-  # Variant of line_of_code_in that pops on string end or newlines.
-  # Used for data binding in Razor components.
-  razor_single_quote_line_of_code_in:
-    - meta_prepend: true
-    - include: razor-comments
-    - match: "(?=')"
-      scope: string.quoted.single.html punctuation.definition.string.end.html
-      pop: 1
-    - match: '$\n?'
-      pop: 1
-    - include: line_of_code_in
-  razor_double_quote_line_of_code_in:
-    - meta_prepend: true
-    - include: razor-comments
-    - match: '(?=\")'
-      scope: string.quoted.double.html punctuation.definition.string.end.html
-      pop: 1
-    - match: '$\n?'
-      pop: 1
-    - include: line_of_code_in
-
-  # Variant of line_of_code_in that handles just an expression and pops on ) or newlines.
-  razor_expression_in:
-    - meta_prepend: true
-    - include: razor-comments
-    - match: '\)'
-      scope: keyword.other.inline.end.razor
-      pop: 1
-    - match: '$\n?'
-      pop: 1
-    - include: line_of_code_in
-
-  # Enables use of templated Razor delegates.
-  variables_declaration:
-    - meta_prepend: true
-    - include: razor-comments
-    - match: '='
-      scope: keyword.operator.assignment.variable.cs
-      push:
-        - match: '\@(?=<)'
-          scope: keyword.other.embed.html.razor
-          push: scope:source.razor#tag-html-nested-start
-        - match: (?=;|,)
-          pop: 1
-        - match: (?=\{)
-          push:
-            - match: (?=[^,\s{}])
-              pop: 1
-            - include: initializer_constructor
-        - include: line_of_code_in
+      push: scope:source.razor#tag-html-nested-start

--- a/syntax/Razor C# (CSharp).sublime-syntax
+++ b/syntax/Razor C# (CSharp).sublime-syntax
@@ -54,7 +54,7 @@ contexts:
     - match: \{
       scope: punctuation.section.block.begin.cs
       set: inside-statement-block
-    - include: stray-punctuations
+    - include: stray-punctuation
     # conditional statements
     - match: if\b
       scope: keyword.control.conditional.if.cs
@@ -249,7 +249,7 @@ contexts:
         2: entity.name.tag.html
         3: punctuation.definition.tag.end.html.razor
       embed: scope:source.razor
-      embed_scope: embed.text.html
+      embed_scope: embed.text.html.razor
       escape: '(</)(text)(>)'
       escape_captures:
         1: punctuation.definition.tag.begin.html.razor
@@ -261,7 +261,7 @@ contexts:
     - match: '(\@)\:'
       scope: keyword.other.embed.html.razor
       captures:
-        1: punctuation.definition.keyword.razor
+        1: punctuation.definition.embedded.razor
       embed: scope:source.razor
       escape: '$\n?'
 
@@ -274,7 +274,7 @@ contexts:
         2: entity.name.tag.html
         3: punctuation.definition.tag.end.html.razor
       embed: scope:source.razor
-      embed_scope: embed.text.html
+      embed_scope: embed.text.html.razor
       escape: '(</)(text)(>)'
       escape_captures:
         1: punctuation.definition.tag.begin.html.razor
@@ -285,7 +285,7 @@ contexts:
       push: scope:source.razor#tag-html-embed
     - match: '(\@)(\:)'
       captures:
-        1: punctuation.definition.keyword.razor
+        1: punctuation.definition.embedded.razor
         2: keyword.other.embed.html.razor
       embed: scope:source.razor
       escape: '$\n?'
@@ -295,5 +295,5 @@ contexts:
   assignment-value:
     - meta_prepend: true
     - match: '\@(?=<)'
-      scope: punctuation.definition.keyword.razor
+      scope: punctuation.definition.embedded.razor
       push: scope:source.razor#tag-html-nested-start

--- a/syntax/Razor C# (CSharp).sublime-syntax
+++ b/syntax/Razor C# (CSharp).sublime-syntax
@@ -161,6 +161,11 @@ contexts:
     - match: '$\n?'
       pop: 1
     - include: expression
+  razor-unquoted-expression:
+    - match: (?=[\t\n\f ]|/?>)
+      pop: 1
+    - include: razor-comments
+    - include: expression
 
   # Formats braces.
   inside-razor-csharp-block:

--- a/syntax/Razor C# (CSharp).sublime-syntax
+++ b/syntax/Razor C# (CSharp).sublime-syntax
@@ -147,18 +147,16 @@ contexts:
   # Used for data binding in Razor components.
   razor-single-quote-expression:
     - include: razor-comments
-    - match: "(?=')"
-      scope: string.quoted.single.html punctuation.definition.string.end.html
+    - match: (?=')
       pop: 1
-    - match: '$\n?'
+    - match: $
       pop: 1
     - include: expression
   razor-double-quote-expression:
     - include: razor-comments
-    - match: '(?=\")'
-      scope: string.quoted.double.html punctuation.definition.string.end.html
+    - match: (?=")
       pop: 1
-    - match: '$\n?'
+    - match: $
       pop: 1
     - include: expression
 

--- a/syntax/Razor C# (CSharp).sublime-syntax
+++ b/syntax/Razor C# (CSharp).sublime-syntax
@@ -40,12 +40,72 @@ contexts:
       scope: entity.name.interface.cs
       set: type-constraints
 
-  # A single statement that actually ends.
+  # A single statement, with overrides to support a block after statements that require blocks.
+  # The C# syntax doesn't enforce blocks anymore, but we need them so we can keep ourselves in C# mode and not
+  # immediately fall back to HTML mode.
   razor-statement-eol:
     - match: '(?=<)'
       pop: 1
     - match: '$\n?'
       pop: 1
+    # conditional statements
+    - match: if\b
+      scope: keyword.control.conditional.if.cs
+      set:
+        - razor-fix-statement-if
+        - maybe-statement-block
+        - maybe-expression-group
+    - match: switch\b
+      scope: keyword.control.conditional.switch.cs
+      set:
+        - maybe-statement-block
+        - maybe-expression-group
+    # exception statements
+    - match: try\b
+      scope: keyword.control.exception.try.cs
+      set:
+        - razor-fix-statement-try-catch
+        - maybe-statement-block
+        - maybe-expression-group
+    # loop statements
+    - match: do\b
+      scope: keyword.control.loop.do.cs
+      set:
+        - razor-fix-statement-do-while
+        - maybe-statement-block
+    - match: foreach\b
+      scope: keyword.control.loop.foreach.cs
+      set:
+        - maybe-statement-block
+        - foreach-group
+    - match: for\b
+      scope: keyword.control.loop.for.cs
+      set:
+        - maybe-statement-block
+        - for-group
+    - match: while\b
+      scope: keyword.control.loop.while.cs
+      set:
+        - maybe-statement-block
+        - maybe-expression-group
+    # control flow statements
+    - match: lock\b
+      scope: keyword.control.flow.lock.cs
+      set:
+        - maybe-statement-block
+        - maybe-expression-group
+    # declarations
+    - match: fixed\b
+      scope: keyword.declaration.fixed.cs
+      set:
+        - maybe-statement-block
+        - fixed-group
+    - match: using\b
+      scope: keyword.declaration.using.cs
+      set:
+        - maybe-statement-block
+        - using-body
+    #
     - include: inside-statement-block
 
   # Variant of expression that pops on HTML or newlines.
@@ -56,6 +116,7 @@ contexts:
       pop: 1
     - include: parens
     - include: lambdas
+    # Override to include the generic so we don't pop early.
     - match: '{{name}}(?={{generic_declaration}}\s*\.)'
       scope: support.type.cs
       pop: 1
@@ -91,9 +152,8 @@ contexts:
       pop: 1
     - include: expression
 
-  # Allows proper formatting on the final closing brace.
+  # Formats braces.
   inside-razor-csharp-block:
-    - meta_prepend: true
     - meta_scope: meta.block.cs
     # Pop at the end of the block so we transition back to HTML correctly.
     - match: '\}'
@@ -101,19 +161,55 @@ contexts:
       pop: 1
     - include: inside-csharp-block
 
+###[ C# BLOCK FIXES ]##########################################################
+
+  # The C# syntax doesn't enforce blocks, which is troublesome because we need to know if we should stay in C# mode or switch back to HTML mode.
+  # These fixes will let us handle chained blocks, like if/else or try/catch scenarios, by explicitly looking for continuation statements.
+
+  razor-fix-statement-if:
+    - match: else\s+if\b
+      scope: keyword.control.conditional.elseif.cs
+      set:
+        - razor-fix-statement-if
+        - maybe-statement-block
+        - maybe-expression-group
+    - match: else\b
+      scope: keyword.control.conditional.else.cs
+      set: maybe-statement-block
+    - match: (?=\S)
+      pop: 1
+
+  razor-fix-statement-do-while:
+    - match: while\b
+      scope: keyword.control.loop.while.cs
+      set: maybe-expression-group
+    - match: (?=\S)
+      pop: 1
+
+  razor-fix-statement-try-catch:
+    - match: catch\b
+      scope: keyword.control.exception.catch.cs
+      set:
+        - razor-fix-statement-try-catch
+        - maybe-statement-block
+        - catch-guard
+        - catch-group
+    - match: finally\b
+      scope: keyword.control.exception.finally.cs
+      set:
+        - razor-fix-statement-try-catch
+        - maybe-statement-block
+    - match: (?=\S)
+      pop: 1
+
 ###[ C# OVERRIDES ]############################################################
 
   # Allows HTML context switching and Razor comments.
-  expression:
+  expression-common:
     - meta_prepend: true
     - match: '\@(?=<)'
       scope: keyword.other.embed.html.razor
       push: scope:source.razor#tag-html-embed
-
-  expression-common:
-    - meta_prepend: true
-    - match: '(?=<)'
-      pop: 1
 
   inside-csharp-block:
     - meta_prepend: true
@@ -139,7 +235,32 @@ contexts:
       embed: scope:source.razor
       escape: '$\n?'
 
+  inside-statement-block:
+    - meta_prepend: true
+    - meta_scope: meta.block.cs
+    # Support <text></text>.
+    - match: '(<)(text)(>)'
+      captures:
+        1: punctuation.definition.tag.begin.html.razor
+        2: entity.name.tag.html
+        3: punctuation.definition.tag.end.html.razor
+      embed: scope:source.razor
+      embed_scope: embed.text.html
+      escape: '(</)(text)(>)'
+      escape_captures:
+        1: punctuation.definition.tag.begin.html.razor
+        2: entity.name.tag.html
+        3: punctuation.definition.tag.end.html.razor
+    # HTML context switching.
+    - match: '(?=<)'
+      push: scope:source.razor#tag-html-embed
+    - match: '\@\:'
+      scope: keyword.other.embed.html.razor
+      embed: scope:source.razor
+      escape: '$\n?'
+
   # Enables use of templated Razor delegates.
+  # These are things like: Func<dynamic, object> petTemplate = @<p>You have a pet named <strong>@item.Name</strong>.</p>;
   assignment-value:
     - meta_prepend: true
     - include: razor-comments

--- a/syntax/Razor C# (CSharp).sublime-syntax
+++ b/syntax/Razor C# (CSharp).sublime-syntax
@@ -220,7 +220,6 @@ contexts:
 
   inside-csharp-block:
     - meta_prepend: true
-    - meta_scope: meta.block.cs
     # Support <text></text>.
     - match: '(<)(text)(>)'
       captures:
@@ -244,7 +243,6 @@ contexts:
 
   inside-statement-block:
     - meta_prepend: true
-    - meta_scope: meta.block.cs
     # Support <text></text>.
     - match: '(<)(text)(>)'
       captures:

--- a/syntax/Razor C# (CSharp).sublime-syntax
+++ b/syntax/Razor C# (CSharp).sublime-syntax
@@ -187,15 +187,13 @@ contexts:
     - match: else\b
       scope: keyword.control.conditional.else.cs
       set: razor-maybe-statement
-    - match: (?=\S)
-      pop: 1
+    - include: else-pop
 
   razor-maybe-while-statement:
     - match: while\b
       scope: keyword.control.loop.while.cs
       set: maybe-expression-group
-    - match: (?=\S)
-      pop: 1
+    - include: else-pop
 
   razor-maybe-catch-statement:
     - match: catch\b
@@ -210,8 +208,7 @@ contexts:
       set:
         - razor-maybe-catch-statement
         - razor-maybe-statement
-    - match: (?=\S)
-      pop: 1
+    - include: else-pop
 
 ###[ C# OVERRIDES ]############################################################
 

--- a/syntax/Razor C# (CSharp).sublime-syntax
+++ b/syntax/Razor C# (CSharp).sublime-syntax
@@ -48,76 +48,74 @@ contexts:
       pop: 1
     - match: '$\n?'
       pop: 1
-    - include: razor-embedded-statement
+    - include: razor-statement
 
-  razor-embedded-statement:
+  razor-statement:
+    - match: \{
+      scope: punctuation.section.block.begin.cs
+      set: inside-statement-block
+    - include: stray-punctuations
     # conditional statements
     - match: if\b
       scope: keyword.control.conditional.if.cs
       set:
         - razor-maybe-ifelse-statement
-        - razor-maybe-statement
+        - razor-statement
         - maybe-expression-group
     - match: switch\b
       scope: keyword.control.conditional.switch.cs
       set:
-        - razor-maybe-statement
+        - razor-statement
         - maybe-expression-group
     # exception statements
     - match: try\b
       scope: keyword.control.exception.try.cs
       set:
         - razor-maybe-catch-statement
-        - razor-maybe-statement
+        - razor-statement
         - maybe-expression-group
     # loop statements
     - match: do\b
       scope: keyword.control.loop.do.cs
       set:
         - razor-maybe-while-statement
-        - razor-maybe-statement
+        - razor-statement
     - match: foreach\b
       scope: keyword.control.loop.foreach.cs
       set:
-        - razor-maybe-statement
+        - razor-statement
         - foreach-group
     - match: for\b
       scope: keyword.control.loop.for.cs
       set:
-        - razor-maybe-statement
+        - razor-statement
         - for-group
     - match: while\b
       scope: keyword.control.loop.while.cs
       set:
-        - razor-maybe-statement
+        - razor-statement
         - maybe-expression-group
     # control flow statements
     - match: lock\b
       scope: keyword.control.flow.lock.cs
       set:
-        - razor-maybe-statement
+        - razor-statement
         - maybe-expression-group
     # declarations
     - match: fixed\b
       scope: keyword.declaration.fixed.cs
       set:
-        - razor-maybe-statement
+        - razor-statement
         - fixed-group
     - match: using\b
       scope: keyword.declaration.using.cs
       set:
-        - razor-maybe-statement
+        - razor-statement
         - using-body
-    #
-    - include: inside-statement-block
-
-  # Custom statement block that will also allow a single statement.
-  razor-maybe-statement:
-    - match: \{
-      scope: punctuation.section.block.begin.cs
-      set: inside-statement-block
-    - include: razor-embedded-statement
-    - include: else-pop
+    - include: local-declarations
+    # expressions
+    - match: (?=\S)
+      set: razor-expression-eol
 
   # Variant of expression that pops on HTML or newlines.
   razor-expression-eol:
@@ -125,6 +123,7 @@ contexts:
       pop: 1
     - match: '$\n?'
       pop: 1
+    - include: terminators
     - include: parens
     - include: lambdas
     # Override to include the generic so we don't pop early.
@@ -182,11 +181,11 @@ contexts:
       scope: keyword.control.conditional.elseif.cs
       set:
         - razor-maybe-ifelse-statement
-        - razor-maybe-statement
+        - razor-statement
         - maybe-expression-group
     - match: else\b
       scope: keyword.control.conditional.else.cs
-      set: razor-maybe-statement
+      set: razor-statement
     - include: else-pop
 
   razor-maybe-while-statement:
@@ -200,14 +199,14 @@ contexts:
       scope: keyword.control.exception.catch.cs
       set:
         - razor-maybe-catch-statement
-        - razor-maybe-statement
+        - razor-statement
         - catch-guard
         - catch-group
     - match: finally\b
       scope: keyword.control.exception.finally.cs
       set:
         - razor-maybe-catch-statement
-        - razor-maybe-statement
+        - razor-statement
     - include: else-pop
 
 ###[ C# OVERRIDES ]############################################################

--- a/syntax/Razor C# (CSharp).sublime-syntax
+++ b/syntax/Razor C# (CSharp).sublime-syntax
@@ -56,63 +56,63 @@ contexts:
       scope: keyword.control.conditional.if.cs
       set:
         - razor-fix-statement-if
-        - razor-maybe-statement-block
+        - razor-maybe-statement
         - maybe-expression-group
     - match: switch\b
       scope: keyword.control.conditional.switch.cs
       set:
-        - razor-maybe-statement-block
+        - razor-maybe-statement
         - maybe-expression-group
     # exception statements
     - match: try\b
       scope: keyword.control.exception.try.cs
       set:
         - razor-fix-statement-try-catch
-        - razor-maybe-statement-block
+        - razor-maybe-statement
         - maybe-expression-group
     # loop statements
     - match: do\b
       scope: keyword.control.loop.do.cs
       set:
         - razor-fix-statement-do-while
-        - razor-maybe-statement-block
+        - razor-maybe-statement
     - match: foreach\b
       scope: keyword.control.loop.foreach.cs
       set:
-        - razor-maybe-statement-block
+        - razor-maybe-statement
         - foreach-group
     - match: for\b
       scope: keyword.control.loop.for.cs
       set:
-        - razor-maybe-statement-block
+        - razor-maybe-statement
         - for-group
     - match: while\b
       scope: keyword.control.loop.while.cs
       set:
-        - razor-maybe-statement-block
+        - razor-maybe-statement
         - maybe-expression-group
     # control flow statements
     - match: lock\b
       scope: keyword.control.flow.lock.cs
       set:
-        - razor-maybe-statement-block
+        - razor-maybe-statement
         - maybe-expression-group
     # declarations
     - match: fixed\b
       scope: keyword.declaration.fixed.cs
       set:
-        - razor-maybe-statement-block
+        - razor-maybe-statement
         - fixed-group
     - match: using\b
       scope: keyword.declaration.using.cs
       set:
-        - razor-maybe-statement-block
+        - razor-maybe-statement
         - using-body
     #
     - include: inside-statement-block
 
   # Custom statement block that will also allow a single statement.
-  razor-maybe-statement-block:
+  razor-maybe-statement:
     - match: \{
       scope: punctuation.section.block.begin.cs
       set: inside-statement-block
@@ -182,11 +182,11 @@ contexts:
       scope: keyword.control.conditional.elseif.cs
       set:
         - razor-fix-statement-if
-        - razor-maybe-statement-block
+        - razor-maybe-statement
         - maybe-expression-group
     - match: else\b
       scope: keyword.control.conditional.else.cs
-      set: razor-maybe-statement-block
+      set: razor-maybe-statement
     - match: (?=\S)
       pop: 1
 
@@ -202,14 +202,14 @@ contexts:
       scope: keyword.control.exception.catch.cs
       set:
         - razor-fix-statement-try-catch
-        - razor-maybe-statement-block
+        - razor-maybe-statement
         - catch-guard
         - catch-group
     - match: finally\b
       scope: keyword.control.exception.finally.cs
       set:
         - razor-fix-statement-try-catch
-        - razor-maybe-statement-block
+        - razor-maybe-statement
     - match: (?=\S)
       pop: 1
 

--- a/syntax/Razor C# (CSharp).sublime-syntax
+++ b/syntax/Razor C# (CSharp).sublime-syntax
@@ -48,9 +48,9 @@ contexts:
       pop: 1
     - match: '$\n?'
       pop: 1
-    - include: razor-embedded-statements
+    - include: razor-embedded-statement
 
-  razor-embedded-statements:
+  razor-embedded-statement:
     # conditional statements
     - match: if\b
       scope: keyword.control.conditional.if.cs
@@ -116,7 +116,7 @@ contexts:
     - match: \{
       scope: punctuation.section.block.begin.cs
       set: inside-statement-block
-    - include: razor-embedded-statements
+    - include: razor-embedded-statement
     - include: else-pop
 
   # Variant of expression that pops on HTML or newlines.

--- a/syntax/Razor C# (CSharp).sublime-syntax
+++ b/syntax/Razor C# (CSharp).sublime-syntax
@@ -141,7 +141,6 @@ contexts:
 
   # Variant of expression that handles just an expression and pops on ) or newlines.
   razor-expression-explicit:
-    - include: razor-comments
     - match: '\)'
       scope: keyword.other.inline.end.razor
       pop: 1
@@ -152,14 +151,12 @@ contexts:
   # Variant of expression that pops on string end or newlines.
   # Used for data binding in Razor components.
   razor-single-quote-expression:
-    - include: razor-comments
     - match: (?=')
       pop: 1
     - match: $
       pop: 1
     - include: expression
   razor-double-quote-expression:
-    - include: razor-comments
     - match: (?=")
       pop: 1
     - match: $
@@ -168,14 +165,12 @@ contexts:
   razor-unquoted-expression:
     - match: (?=[\t\n\f ]|/?>)
       pop: 1
-    - include: razor-comments
     - include: expression
 
   # Variant of expression that pops on string end or newlines.
   # Used for data binding in Razor components.
   razor-single-quote-attribute-annotation:
     - meta_scope: meta.annotation.cs
-    - include: razor-comments
     - match: (?=')
       pop: 1
     - match: $
@@ -183,7 +178,6 @@ contexts:
     - include: inside-attribute
   razor-double-quote-attribute-annotation:
     - meta_scope: meta.annotation.cs
-    - include: razor-comments
     - match: (?=")
       pop: 1
     - match: $
@@ -300,7 +294,6 @@ contexts:
   # These are things like: Func<dynamic, object> petTemplate = @<p>You have a pet named <strong>@item.Name</strong>.</p>;
   assignment-value:
     - meta_prepend: true
-    - include: razor-comments
     - match: '\@(?=<)'
       scope: punctuation.definition.keyword.razor
       push: scope:source.razor#tag-html-nested-start

--- a/syntax/Razor C# (CSharp).sublime-syntax
+++ b/syntax/Razor C# (CSharp).sublime-syntax
@@ -48,65 +48,76 @@ contexts:
       pop: 1
     - match: '$\n?'
       pop: 1
+    - include: razor-embedded-statements
+
+  razor-embedded-statements:
     # conditional statements
     - match: if\b
       scope: keyword.control.conditional.if.cs
       set:
         - razor-fix-statement-if
-        - maybe-statement-block
+        - razor-maybe-statement-block
         - maybe-expression-group
     - match: switch\b
       scope: keyword.control.conditional.switch.cs
       set:
-        - maybe-statement-block
+        - razor-maybe-statement-block
         - maybe-expression-group
     # exception statements
     - match: try\b
       scope: keyword.control.exception.try.cs
       set:
         - razor-fix-statement-try-catch
-        - maybe-statement-block
+        - razor-maybe-statement-block
         - maybe-expression-group
     # loop statements
     - match: do\b
       scope: keyword.control.loop.do.cs
       set:
         - razor-fix-statement-do-while
-        - maybe-statement-block
+        - razor-maybe-statement-block
     - match: foreach\b
       scope: keyword.control.loop.foreach.cs
       set:
-        - maybe-statement-block
+        - razor-maybe-statement-block
         - foreach-group
     - match: for\b
       scope: keyword.control.loop.for.cs
       set:
-        - maybe-statement-block
+        - razor-maybe-statement-block
         - for-group
     - match: while\b
       scope: keyword.control.loop.while.cs
       set:
-        - maybe-statement-block
+        - razor-maybe-statement-block
         - maybe-expression-group
     # control flow statements
     - match: lock\b
       scope: keyword.control.flow.lock.cs
       set:
-        - maybe-statement-block
+        - razor-maybe-statement-block
         - maybe-expression-group
     # declarations
     - match: fixed\b
       scope: keyword.declaration.fixed.cs
       set:
-        - maybe-statement-block
+        - razor-maybe-statement-block
         - fixed-group
     - match: using\b
       scope: keyword.declaration.using.cs
       set:
-        - maybe-statement-block
+        - razor-maybe-statement-block
         - using-body
     #
     - include: inside-statement-block
+
+  # Custom statement block that will also allow a single statement.
+  razor-maybe-statement-block:
+    - match: \{
+      scope: punctuation.section.block.begin.cs
+      set: inside-statement-block
+    - include: razor-embedded-statements
+    - include: else-pop
 
   # Variant of expression that pops on HTML or newlines.
   razor-expression-eol:
@@ -171,11 +182,11 @@ contexts:
       scope: keyword.control.conditional.elseif.cs
       set:
         - razor-fix-statement-if
-        - maybe-statement-block
+        - razor-maybe-statement-block
         - maybe-expression-group
     - match: else\b
       scope: keyword.control.conditional.else.cs
-      set: maybe-statement-block
+      set: razor-maybe-statement-block
     - match: (?=\S)
       pop: 1
 
@@ -191,14 +202,14 @@ contexts:
       scope: keyword.control.exception.catch.cs
       set:
         - razor-fix-statement-try-catch
-        - maybe-statement-block
+        - razor-maybe-statement-block
         - catch-guard
         - catch-group
     - match: finally\b
       scope: keyword.control.exception.finally.cs
       set:
         - razor-fix-statement-try-catch
-        - maybe-statement-block
+        - razor-maybe-statement-block
     - match: (?=\S)
       pop: 1
 

--- a/syntax/Razor C# (CSharp).sublime-syntax
+++ b/syntax/Razor C# (CSharp).sublime-syntax
@@ -115,10 +115,10 @@ contexts:
     - include: local-declarations
     # expressions
     - match: (?=\S)
-      set: razor-expression-eol
+      set: razor-expression-implicit
 
   # Variant of expression that pops on HTML or newlines.
-  razor-expression-eol:
+  razor-expression-implicit:
     - match: '(?=<)'
       pop: 1
     - match: '$\n?'
@@ -126,15 +126,21 @@ contexts:
     - include: terminators
     - include: parens
     - include: lambdas
-    # Override to include the generic so we don't pop early.
-    - match: '{{name}}(?={{generic_declaration}}\s*\.)'
-      scope: support.type.cs
+    # Override to not include the generic, nor allow extraneous whitespace.
+    # Razor will only allow the generic inside explicit Razor expressions.
+    - match: '{{name}}(?={{generic_declaration}})'
+      scope: variable.other.cs
       pop: 1
+    - match: '{{name}}(?=\()'
+      scope: meta.function-call.identifier.cs variable.function.cs
+      push:
+        - function-call-argument-list
+        - type-argument-list
     - include: expression-common
     - include: else-pop
 
   # Variant of expression that handles just an expression and pops on ) or newlines.
-  razor-expression-paren:
+  razor-expression-explicit:
     - include: razor-comments
     - match: '\)'
       scope: keyword.other.inline.end.razor
@@ -165,12 +171,31 @@ contexts:
     - include: razor-comments
     - include: expression
 
+  # Variant of expression that pops on string end or newlines.
+  # Used for data binding in Razor components.
+  razor-single-quote-attribute-annotation:
+    - meta_scope: meta.annotation.cs
+    - include: razor-comments
+    - match: (?=')
+      pop: 1
+    - match: $
+      pop: 1
+    - include: inside-attribute
+  razor-double-quote-attribute-annotation:
+    - meta_scope: meta.annotation.cs
+    - include: razor-comments
+    - match: (?=")
+      pop: 1
+    - match: $
+      pop: 1
+    - include: inside-attribute
+
   # Formats braces.
   inside-razor-csharp-block:
     - meta_scope: meta.block.cs
     # Pop at the end of the block so we transition back to HTML correctly.
     - match: '\}'
-      scope: keyword.other.block.razor punctuation.block.end.razor
+      scope: punctuation.section.block.end.razor keyword.other.block.razor
       pop: 1
     - include: inside-csharp-block
 
@@ -239,8 +264,10 @@ contexts:
     # HTML context switching.
     - match: '(?=<)'
       push: scope:source.razor#tag-html-embed
-    - match: '\@\:'
+    - match: '(\@)\:'
       scope: keyword.other.embed.html.razor
+      captures:
+        1: punctuation.definition.keyword.razor
       embed: scope:source.razor
       escape: '$\n?'
 
@@ -262,8 +289,10 @@ contexts:
     # HTML context switching.
     - match: '(?=<)'
       push: scope:source.razor#tag-html-embed
-    - match: '\@\:'
-      scope: keyword.other.embed.html.razor
+    - match: '(\@)(\:)'
+      captures:
+        1: punctuation.definition.keyword.razor
+        2: keyword.other.embed.html.razor
       embed: scope:source.razor
       escape: '$\n?'
 
@@ -273,5 +302,5 @@ contexts:
     - meta_prepend: true
     - include: razor-comments
     - match: '\@(?=<)'
-      scope: keyword.other.embed.html.razor
+      scope: punctuation.definition.keyword.razor
       push: scope:source.razor#tag-html-nested-start

--- a/syntax/Razor C# (CSharp).sublime-syntax
+++ b/syntax/Razor C# (CSharp).sublime-syntax
@@ -55,7 +55,7 @@ contexts:
     - match: if\b
       scope: keyword.control.conditional.if.cs
       set:
-        - razor-fix-statement-if
+        - razor-maybe-ifelse-statement
         - razor-maybe-statement
         - maybe-expression-group
     - match: switch\b
@@ -67,14 +67,14 @@ contexts:
     - match: try\b
       scope: keyword.control.exception.try.cs
       set:
-        - razor-fix-statement-try-catch
+        - razor-maybe-catch-statement
         - razor-maybe-statement
         - maybe-expression-group
     # loop statements
     - match: do\b
       scope: keyword.control.loop.do.cs
       set:
-        - razor-fix-statement-do-while
+        - razor-maybe-while-statement
         - razor-maybe-statement
     - match: foreach\b
       scope: keyword.control.loop.foreach.cs
@@ -177,11 +177,11 @@ contexts:
   # The C# syntax doesn't enforce blocks, which is troublesome because we need to know if we should stay in C# mode or switch back to HTML mode.
   # These fixes will let us handle chained blocks, like if/else or try/catch scenarios, by explicitly looking for continuation statements.
 
-  razor-fix-statement-if:
+  razor-maybe-ifelse-statement:
     - match: else\s+if\b
       scope: keyword.control.conditional.elseif.cs
       set:
-        - razor-fix-statement-if
+        - razor-maybe-ifelse-statement
         - razor-maybe-statement
         - maybe-expression-group
     - match: else\b
@@ -190,25 +190,25 @@ contexts:
     - match: (?=\S)
       pop: 1
 
-  razor-fix-statement-do-while:
+  razor-maybe-while-statement:
     - match: while\b
       scope: keyword.control.loop.while.cs
       set: maybe-expression-group
     - match: (?=\S)
       pop: 1
 
-  razor-fix-statement-try-catch:
+  razor-maybe-catch-statement:
     - match: catch\b
       scope: keyword.control.exception.catch.cs
       set:
-        - razor-fix-statement-try-catch
+        - razor-maybe-catch-statement
         - razor-maybe-statement
         - catch-guard
         - catch-group
     - match: finally\b
       scope: keyword.control.exception.finally.cs
       set:
-        - razor-fix-statement-try-catch
+        - razor-maybe-catch-statement
         - razor-maybe-statement
     - match: (?=\S)
       pop: 1

--- a/syntax/Razor C# (Razor).sublime-syntax
+++ b/syntax/Razor C# (Razor).sublime-syntax
@@ -66,7 +66,7 @@ contexts:
       embed: scope:embed.source.cs.razor#razor-type-with-constraint
       escape: $\n?
 
-  # Insert a code block.
+  # Insert a colored code block.
   cs-block:
     - match: '\{'
       scope: keyword.other.block.razor punctuation.block.begin.razor
@@ -81,11 +81,11 @@ contexts:
   block:
     - match: '\b(?=using\s*\()'
       scope: keyword.other.expression.razor
-      set: [scope:embed.source.cs.razor#razor-statement-eol]
+      set: scope:embed.source.cs.razor#razor-statement-eol
 
     - match: '\b(?={{razor_keywords_expression_block}})\b'
       scope: keyword.other.expression.razor
-      set: [scope:embed.source.cs.razor#razor-statement-eol]
+      set: scope:embed.source.cs.razor#razor-statement-eol
 
     - match: '\b(functions|code)\b'
       scope: keyword.other.code.block.razor
@@ -117,7 +117,9 @@ contexts:
 
     - match: '\b(inject)\b\s+'
       scope: keyword.other.inject.razor
-      set: [cs-variable, cs-interface]
+      set:
+        - cs-variable
+        - cs-interface
 
     - match: '\b(namespace)\b\s+'
       scope: keyword.other.namespace.razor
@@ -205,10 +207,14 @@ contexts:
       set:
         - match: \'
           scope: string.quoted.single.html punctuation.definition.string.begin.html
-          set: [end-single-quoted, scope:embed.source.cs.razor#razor-single-quote-expression]
+          set:
+            - end-single-quoted
+            - scope:embed.source.cs.razor#razor-single-quote-expression
         - match: \"
           scope: string.quoted.double.html punctuation.definition.string.begin.html
-          set: [end-double-quoted, scope:embed.source.cs.razor#razor-double-quote-expression]
+          set:
+            - end-double-quoted
+            - scope:embed.source.cs.razor#razor-double-quote-expression
 
     # Attribute data bindings that are just normal HTML strings.
     - match: '\b(formname)\b'

--- a/syntax/Razor C# (Razor).sublime-syntax
+++ b/syntax/Razor C# (Razor).sublime-syntax
@@ -13,7 +13,7 @@ variables:
   name_normal: '{{start_char}}{{other_char}}*\b'
 
   razor_rendermodes: '(InteractiveServer|InteractiveWebAssembly|InteractiveAuto)'
-  razor_keywords_expression_block: '(?xi: if | switch | for | foreach | while | do | try | lock)'
+  razor_keywords_expression_block: '(?xi: if | switch | for | foreach | while | do | try | lock )'
 
 #############################
 
@@ -40,7 +40,7 @@ contexts:
   cs-namespace:
     - match: '(?=\S)'
       pop: 1
-      embed: scope:embed.source.cs.razor#using_namespace
+      embed: scope:embed.source.cs.razor#using-namespace
       escape: (?=\s|$\n?)
 
   # Insert an interface.
@@ -53,26 +53,24 @@ contexts:
   cs-variable:
     - match: '(?=\S)'
       pop: 1
-      embed: scope:embed.source.cs.razor#var_declaration_explicit
+      embed: scope:embed.source.cs.razor#var-declarator
       escape: (?=\s|$\n?)
 
   # Inserts a type.
   cs-type:
     - match: '(?=\S)'
-      pop: 1
-      embed: scope:embed.source.cs.razor#type_no_space
-      escape: (?=\s|$\n?)
+      set: scope:embed.source.cs.razor#maybe-type
   cs-type-constraint:
     - match: '(?=\S)'
       pop: 1
-      embed: scope:embed.source.cs.razor#razor_type_with_constraint
+      embed: scope:embed.source.cs.razor#razor-type-with-constraint
       escape: $\n?
 
   # Insert a code block.
   cs-block:
     - match: '\{'
       scope: keyword.other.block.razor punctuation.block.begin.razor
-      set: scope:embed.source.cs.razor#code_block_in
+      set: scope:embed.source.cs.razor#inside-razor-csharp-block
 
   keyword:
     - include: component-directive
@@ -81,15 +79,13 @@ contexts:
     - include: mvc-directive
 
   block:
-    - match: '\b(using)\s*(\()'
-      captures:
-        1: keyword.control.using.cs
-        2: meta.group.cs punctuation.section.group.begin.cs
-      set: [scope:embed.source.cs.razor#using_block, scope:embed.source.cs.razor#line_of_code]
+    - match: '\b(?=using\s*\()'
+      scope: keyword.other.expression.razor
+      set: [scope:embed.source.cs.razor#razor-statement-eol]
 
     - match: '\b(?={{razor_keywords_expression_block}})\b'
       scope: keyword.other.expression.razor
-      set: scope:embed.source.cs.razor#line_of_code
+      set: [scope:embed.source.cs.razor#razor-statement-eol]
 
     - match: '\b(functions|code)\b'
       scope: keyword.other.code.block.razor
@@ -100,13 +96,13 @@ contexts:
 
     - match: '\('
       scope: keyword.other.inline.begin.razor
-      set: scope:embed.source.cs.razor#razor_expression_in
+      set: scope:embed.source.cs.razor#razor-expression-paren
 
   general-directive:
     - match: '\b(attribute)\b\s+'
       scope: keyword.other.attribute.razor
       pop: 1
-      embed: scope:embed.source.cs.razor#attribute
+      embed: scope:embed.source.cs.razor#attributes
       escape: \]
       escape_captures:
         0: punctuation.definition.annotation.end.cs
@@ -117,7 +113,7 @@ contexts:
 
     - match: '\b(inherits)\b\s+'
       scope: keyword.other.inherits.razor
-      set: cs-variable
+      set: cs-type
 
     - match: '\b(inject)\b\s+'
       scope: keyword.other.inject.razor
@@ -126,7 +122,7 @@ contexts:
     - match: '\b(namespace)\b\s+'
       scope: keyword.other.namespace.razor
       pop: 1
-      embed: scope:embed.source.cs.razor#namespace_declaration_name
+      embed: scope:embed.source.cs.razor#namespace-declaration-name
       escape: (?=\s|$\n?)
 
     - match: '\b(page)\b\s+'
@@ -154,7 +150,7 @@ contexts:
             - match: '(?=\S)'
               set: cs-namespace
         - match: '(?=\S)'
-          embed: scope:embed.source.cs.razor#var_declaration_explicit
+          embed: scope:embed.source.cs.razor#var-declarator
           escape: (?=\*|,|\s|$\n?)
 
     - match: '\b(tagHelperPrefix)\b\s+'
@@ -166,7 +162,7 @@ contexts:
 
     - match: '\b(model)\b\s+'
       scope: keyword.other.model.razor
-      set: cs-variable
+      set: cs-type
 
     - match: '\b(section)\b\s+({{name_normal}})'
       captures:
@@ -209,10 +205,10 @@ contexts:
       set:
         - match: \'
           scope: string.quoted.single.html punctuation.definition.string.begin.html
-          set: [end-single-quoted, scope:embed.source.cs.razor#razor_single_quote_line_of_code_in]
+          set: [end-single-quoted, scope:embed.source.cs.razor#razor-single-quote-expression]
         - match: \"
           scope: string.quoted.double.html punctuation.definition.string.begin.html
-          set: [end-double-quoted, scope:embed.source.cs.razor#razor_double_quote_line_of_code_in]
+          set: [end-double-quoted, scope:embed.source.cs.razor#razor-double-quote-expression]
 
     # Attribute data bindings that are just normal HTML strings.
     - match: '\b(formname)\b'

--- a/syntax/Razor C# (Razor).sublime-syntax
+++ b/syntax/Razor C# (Razor).sublime-syntax
@@ -91,8 +91,7 @@ contexts:
       scope: keyword.other.code.block.razor
       set: cs-block
 
-    - match: '(?=\{)'
-      set: cs-block
+    - include: cs-block
 
     - match: '\('
       scope: keyword.other.inline.begin.razor

--- a/syntax/Razor C# (Razor).sublime-syntax
+++ b/syntax/Razor C# (Razor).sublime-syntax
@@ -19,6 +19,10 @@ variables:
 
 contexts:
 
+  prototype:
+    - meta_prepend: true
+    - include: razor-comments
+
   main:
     - match: .
       pop: 1
@@ -56,7 +60,6 @@ contexts:
 
   # Insert a namespace.
   cs-namespace:
-    - include: razor-comments
     - match: '(?=\S)'
       pop: 1
       embed: scope:embed.source.cs.razor#using-namespace
@@ -64,14 +67,12 @@ contexts:
 
   # Insert an interface.
   cs-interface:
-    - include: razor-comments
     - match: '{{name_normal}}'
       scope: entity.name.interface.cs
       pop: 1
 
   # Insert a variable.
   cs-variable:
-    - include: razor-comments
     - match: '(?=\S)'
       pop: 1
       embed: scope:embed.source.cs.razor#var-declarator
@@ -79,11 +80,9 @@ contexts:
 
   # Inserts a type.
   cs-type:
-    - include: razor-comments
     - match: '(?=\S)'
       set: scope:embed.source.cs.razor#maybe-type
   cs-type-constraint:
-    - include: razor-comments
     - match: '(?=\S)'
       pop: 1
       embed: scope:embed.source.cs.razor#razor-type-with-constraint
@@ -91,13 +90,11 @@ contexts:
 
   # Insert a colored code block.
   cs-block:
-    - include: razor-comments
     - match: '\{'
       scope: punctuation.section.block.begin.razor keyword.other.block.razor
       set: scope:embed.source.cs.razor#inside-razor-csharp-block
 
   keyword:
-    - include: razor-comments
     - include: component-directive
     - include: block
     - include: general-directive

--- a/syntax/Razor C# (Razor).sublime-syntax
+++ b/syntax/Razor C# (Razor).sublime-syntax
@@ -12,7 +12,7 @@ variables:
   other_char: '(?:{{unicode_char}}|[_0-9\p{L}])'
   name_normal: '{{start_char}}{{other_char}}*\b'
 
-  razor_rendermodes: '(InteractiveServer|InteractiveWebAssembly|InteractiveAuto)'
+  razor_rendermodes: '(?xi: InteractiveServer | InteractiveWebAssembly | InteractiveAuto )'
   razor_keywords_expression_block: '(?xi: if | switch | for | foreach | while | do | try | lock )'
 
 #############################
@@ -22,6 +22,24 @@ contexts:
   main:
     - match: .
       pop: 1
+
+  razor-comments:
+    # E-mail addresses have the @ symbol but don't activate code.
+    - match: '[\+-.\w]+@[-a-z0-9]+(\.[-a-z0-9]+)*'
+      scope: meta.email
+    # Match an escaped @.
+    - match: '@@'
+      scope: constant.character.escape
+    # Match the start of our comment.
+    - match: '@\*'
+      scope: punctuation.definition.comment.begin.razor
+      push:
+        - meta_scope: comment.block.razor
+        - match: '\*@'
+          scope: punctuation.definition.comment.end.razor
+          pop: 1
+    - match: '\*@'
+      scope: invalid.illegal.stray-comment-end.razor
 
   # Pop when a certain goal is reached.
   end-of-line:
@@ -38,6 +56,7 @@ contexts:
 
   # Insert a namespace.
   cs-namespace:
+    - include: razor-comments
     - match: '(?=\S)'
       pop: 1
       embed: scope:embed.source.cs.razor#using-namespace
@@ -45,12 +64,14 @@ contexts:
 
   # Insert an interface.
   cs-interface:
+    - include: razor-comments
     - match: '{{name_normal}}'
       scope: entity.name.interface.cs
       pop: 1
 
   # Insert a variable.
   cs-variable:
+    - include: razor-comments
     - match: '(?=\S)'
       pop: 1
       embed: scope:embed.source.cs.razor#var-declarator
@@ -58,9 +79,11 @@ contexts:
 
   # Inserts a type.
   cs-type:
+    - include: razor-comments
     - match: '(?=\S)'
       set: scope:embed.source.cs.razor#maybe-type
   cs-type-constraint:
+    - include: razor-comments
     - match: '(?=\S)'
       pop: 1
       embed: scope:embed.source.cs.razor#razor-type-with-constraint
@@ -68,11 +91,13 @@ contexts:
 
   # Insert a colored code block.
   cs-block:
+    - include: razor-comments
     - match: '\{'
-      scope: keyword.other.block.razor punctuation.block.begin.razor
+      scope: punctuation.section.block.begin.razor keyword.other.block.razor
       set: scope:embed.source.cs.razor#inside-razor-csharp-block
 
   keyword:
+    - include: razor-comments
     - include: component-directive
     - include: block
     - include: general-directive
@@ -95,16 +120,16 @@ contexts:
 
     - match: '\('
       scope: keyword.other.inline.begin.razor
-      set: scope:embed.source.cs.razor#razor-expression-paren
+      set: scope:embed.source.cs.razor#razor-expression-explicit
 
   general-directive:
-    - match: '\b(attribute)\b\s+'
+    - match: '\b(attribute)\b'
       scope: keyword.other.attribute.razor
       pop: 1
       embed: scope:embed.source.cs.razor#attributes
       escape: \]
       escape_captures:
-        0: punctuation.definition.annotation.end.cs
+        0: meta.annotation.cs punctuation.definition.annotation.end.cs
 
     - match: '\b(implements)\b\s+'
       scope: keyword.other.implements.razor
@@ -197,8 +222,26 @@ contexts:
         3: entity.other.attribute-name.html
       pop: 1
 
+    # Attribute data bindings that takes a C# attribute annotation.
+    - match: '\b(attributes)\b\s*(=)'
+      captures:
+        0: meta.attribute-with-value.style.html
+        1: keyword.other.attribute-bind.razor
+        2: punctuation.separator.key-value.html
+      set:
+        - match: \'
+          scope: string.quoted.single.html punctuation.definition.string.begin.html
+          set:
+            - end-single-quoted
+            - scope:embed.source.cs.razor#razor-single-quote-attribute-annotation
+        - match: \"
+          scope: string.quoted.double.html punctuation.definition.string.begin.html
+          set:
+            - end-double-quoted
+            - scope:embed.source.cs.razor#razor-double-quote-attribute-annotation
+
     # Attribute data bindings that take C# expressions.
-    - match: '\b(attributes|bind|bind:culture|on{{name_normal}}|bind-{{name_normal}}|key|ref)\b\s*(=)'
+    - match: '\b(bind|bind:culture|on{{name_normal}}|bind-{{name_normal}}|key|ref)\b\s*(=)'
       captures:
         0: meta.attribute-with-value.style.html
         1: keyword.other.attribute-bind.razor
@@ -229,20 +272,34 @@ contexts:
         - match: \s+
         - match: \=
           scope: punctuation.separator.key-value.html
-        - match: '(\''){{razor_rendermodes}}(\'')'
+        - match: '(\'')((RenderMode\.)?{{razor_rendermodes}})?(\'')'
+          captures:
+            0: string.quoted.single.html
+            1: punctuation.definition.string.begin.html
+            2: constant.language.rendermode.razor
+            3: punctuation.definition.string.end.html
+          pop: 1
+        - match: '(")((RenderMode\.)?{{razor_rendermodes}})?(")'
           captures:
             0: string.quoted.double.html
             1: punctuation.definition.string.begin.html
             2: constant.language.rendermode.razor
             3: punctuation.definition.string.end.html
           pop: 1
-        - match: '"{{razor_rendermodes}}"'
-          captures:
-            0: string.quoted.double.html
-            1: punctuation.definition.string.begin.html
-            2: constant.language.rendermode.razor
-            3: punctuation.definition.string.end.html
-          pop: 1
-        - match: '{{razor_rendermodes}}'
+        - match: '((RenderMode\.)?{{razor_rendermodes}})'
           scope: constant.language.rendermode.razor
+          pop: 1
+        - match: '(\'').+(\'')'
+          captures:
+            0: string.quoted.single.html
+            1: punctuation.definition.string.begin.html
+            2: punctuation.definition.string.end.html
+          pop: 1
+        - match: '(").+(")'
+          captures:
+            0: string.quoted.double.html
+            1: punctuation.definition.string.begin.html
+            2: punctuation.definition.string.end.html
+          pop: 1
+        - match: \S
           pop: 1

--- a/syntax/Razor C#.sublime-syntax
+++ b/syntax/Razor C#.sublime-syntax
@@ -217,3 +217,10 @@ contexts:
   tag-id-attribute-value-single-quoted-content:
     - meta_prepend: true
     - include: razor-keywords-html-attribute-single-quoted
+
+  tag-generic-attribute-value-double-quoted-content:
+    - meta_prepend: true
+    - include: razor-keywords-html-attribute-double-quoted
+  tag-generic-attribute-value-single-quoted-content:
+    - meta_prepend: true
+    - include: razor-keywords-html-attribute-single-quoted

--- a/syntax/Razor C#.sublime-syntax
+++ b/syntax/Razor C#.sublime-syntax
@@ -73,45 +73,62 @@ contexts:
       scope: invalid.illegal.stray-comment-end.razor
 
   razor-keywords:
-    - meta_scope: embed.source.cs
     # Razor keywords that keep the block in HTML mode.
     - match: '\@(?={{razor_html_default}})'
-      scope: keyword.other.reserved.razor
+      scope: punctuation.definition.keyword.razor
       set: scope:source.razor.engine#keyword
     # Razor keywords that switch to C# default.
     - match: '\@(?={{razor_keywords}})'
-      scope: keyword.other.reserved.razor
+      scope: punctuation.definition.keyword.razor
       push:
         - immediately-pop-cs
         - scope:source.razor.engine#keyword
     # Inline C# expressions.
     - match: '\@'
-      scope: keyword.other.expression.razor
+      scope: punctuation.definition.keyword.razor
       push:
         - immediately-pop-cs
-        - scope:embed.source.cs.razor#razor-expression-eol
+        - scope:embed.source.cs.razor#razor-expression-implicit
 
   # When inside an HTML attribute, we need special handling to deal with switching back to HTML.
   # We also need to clear the string scope.
   # Inline C# expressions only.
   razor-keywords-html-attribute-single-quoted:
     - match: '\@'
-      scope: keyword.other.expression.razor
+      scope: punctuation.definition.keyword.razor
       push:
-        - immediately-pop-cs-clear-string-scope
-        - scope:embed.source.cs.razor#razor-single-quote-expression
+        - match: (?={{razor_keywords}})
+          set:
+            - immediately-pop-cs-clear-string-scope
+            - scope:source.razor.engine#keyword
+        - match: ''
+          set:
+            - immediately-pop-cs-clear-string-scope
+            - scope:embed.source.cs.razor#razor-single-quote-expression
   razor-keywords-html-attribute-double-quoted:
     - match: '\@'
-      scope: keyword.other.expression.razor
+      scope: punctuation.definition.keyword.razor
       push:
-        - immediately-pop-cs-clear-string-scope
-        - scope:embed.source.cs.razor#razor-double-quote-expression
+        - match: (?={{razor_keywords}})
+          set:
+            - immediately-pop-cs-clear-string-scope
+            - scope:source.razor.engine#keyword
+        - match: ''
+          set:
+            - immediately-pop-cs-clear-string-scope
+            - scope:embed.source.cs.razor#razor-double-quote-expression
   razor-keywords-html-attribute-unquoted:
     - match: '\@'
-      scope: punctuation.section.embedded.razor
+      scope: punctuation.definition.keyword.razor
       push:
-        - immediately-pop-cs-clear-string-scope
-        - scope:embed.source.cs.razor#razor-unquoted-expression
+        - match: (?={{razor_keywords}})
+          set:
+            - immediately-pop-cs-clear-string-scope
+            - scope:source.razor.engine#keyword
+        - match: ''
+          set:
+            - immediately-pop-cs-clear-string-scope
+            - scope:embed.source.cs.razor#razor-unquoted-expression
 
   # Enable Razor context switching.
   tag-html:
@@ -125,6 +142,7 @@ contexts:
     - include: razor-keywords
     - match: (<)({{html_block_tags}})
       captures:
+        0: meta.tag.block.any.html
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.block.any.html
       set:
@@ -132,6 +150,7 @@ contexts:
         - block-any-tag-content
     - match: (<)({{html_inline_tags}})
       captures:
+        0: meta.tag.block.any.html
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.inline.any.html
       set:
@@ -139,6 +158,7 @@ contexts:
         - inline-any-tag-content
     - match: (<)((?i:form|fieldset){{tag_name_break}})
       captures:
+        0: meta.tag.block.any.html
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.block.form.html
       set:
@@ -146,6 +166,7 @@ contexts:
         - block-forms-tag-content
     - match: (<)({{html_forms_tags}})
       captures:
+        0: meta.tag.block.any.html
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.inline.form.html
       set:
@@ -153,6 +174,7 @@ contexts:
         - inline-forms-tag-content
     - match: (<)({{html_table_tags}})
       captures:
+        0: meta.tag.block.any.html
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.inline.table.html
       set:
@@ -165,6 +187,7 @@ contexts:
     - include: razor-keywords
     - match: '(</)({{tag_name}})(>)'
       captures:
+        0: meta.tag.block.any.html
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.block.any.html
         3: punctuation.definition.tag.end.html
@@ -178,6 +201,7 @@ contexts:
     - include: razor-comments
     - match: '(</)({{html_block_tags}}|{{html_inline_tags}})'
       captures:
+        0: meta.tag.block.any.html
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.block.any.html
       push:
@@ -189,13 +213,13 @@ contexts:
   # Pop 2 to get us back to C#.
   tag-end-razor:
     - match: '>'
-      scope: punctuation.definition.tag.end.html
+      scope: meta.tag.block.any.html punctuation.definition.tag.end.html
       pop: 2
 
   # Special context to properly get us out of @section blocks.
   razor-section-block:
     - match: '\}'
-      scope: keyword.other.block.razor punctuation.block.end.razor
+      scope: punctuation.section.block.end.razor keyword.other.block.razor
       pop: 2
     - include: main
 

--- a/syntax/Razor C#.sublime-syntax
+++ b/syntax/Razor C#.sublime-syntax
@@ -30,6 +30,8 @@ variables:
 # Without it, comments that start in one language and end in the other won't work properly.
 # This is due to conflicts with the built-in comments assigned to text.html.basic and source.cs.
 
+# Razor syntax last checked as of .NET 10.
+
 #############################
 
 contexts:
@@ -81,7 +83,7 @@ contexts:
     # Inline C# expressions.
     - match: '\@'
       scope: keyword.other.expression.razor
-      push: [immediately-pop-cs, scope:embed.source.cs.razor#razor_line_of_code_in]
+      push: [immediately-pop-cs, scope:embed.source.cs.razor#razor-expression-eol]
 
   # When inside an HTML attribute, we need special handling to deal with switching back to HTML.
   # We also need to clear the string scope.
@@ -89,11 +91,11 @@ contexts:
   razor-keywords-html-attribute-single-quoted:
     - match: '\@'
       scope: keyword.other.expression.razor
-      push: [immediately-pop-cs-clear-string-scope, scope:embed.source.cs.razor#razor_single_quote_line_of_code_in]
+      push: [immediately-pop-cs-clear-string-scope, scope:embed.source.cs.razor#razor-single-quote-expression]
   razor-keywords-html-attribute-double-quoted:
     - match: '\@'
       scope: keyword.other.expression.razor
-      push: [immediately-pop-cs-clear-string-scope, scope:embed.source.cs.razor#razor_double_quote_line_of_code_in]
+      push: [immediately-pop-cs-clear-string-scope, scope:embed.source.cs.razor#razor-double-quote-expression]
 
   # Enable Razor context switching.
   tag-html:

--- a/syntax/Razor C#.sublime-syntax
+++ b/syntax/Razor C#.sublime-syntax
@@ -43,11 +43,13 @@ contexts:
 
   # Used to apply a meta scope to the C# syntax.
   immediately-pop-cs:
+    - meta_include_prototype: false
     - meta_scope: embed.source.cs
     - match: ''
       pop: 1
   immediately-pop-cs-clear-string-scope:
     - clear_scopes: 1
+    - meta_include_prototype: false
     - meta_scope: embed.source.cs
     - match: ''
       pop: 1
@@ -104,6 +106,12 @@ contexts:
       push:
         - immediately-pop-cs-clear-string-scope
         - scope:embed.source.cs.razor#razor-double-quote-expression
+  razor-keywords-html-attribute-unquoted:
+    - match: '\@'
+      scope: punctuation.section.embedded.razor
+      push:
+        - immediately-pop-cs-clear-string-scope
+        - scope:embed.source.cs.razor#razor-unquoted-expression
 
   # Enable Razor context switching.
   tag-html:
@@ -203,6 +211,9 @@ contexts:
   tag-class-attribute-value-single-quoted-content:
     - meta_prepend: true
     - include: razor-keywords-html-attribute-single-quoted
+  tag-class-attribute-value-unquoted-content:
+    - meta_prepend: true
+    - include: razor-keywords-html-attribute-unquoted
 
   tag-href-attribute-value-double-quoted-content:
     - meta_prepend: true
@@ -210,6 +221,9 @@ contexts:
   tag-href-attribute-value-single-quoted-content:
     - meta_prepend: true
     - include: razor-keywords-html-attribute-single-quoted
+  tag-href-attribute-value-unquoted-content:
+    - meta_prepend: true
+    - include: razor-keywords-html-attribute-unquoted
 
   tag-id-attribute-value-double-quoted-content:
     - meta_prepend: true
@@ -217,6 +231,9 @@ contexts:
   tag-id-attribute-value-single-quoted-content:
     - meta_prepend: true
     - include: razor-keywords-html-attribute-single-quoted
+  tag-id-attribute-value-unquoted-content:
+    - meta_prepend: true
+    - include: razor-keywords-html-attribute-unquoted
 
   tag-generic-attribute-value-double-quoted-content:
     - meta_prepend: true
@@ -224,3 +241,6 @@ contexts:
   tag-generic-attribute-value-single-quoted-content:
     - meta_prepend: true
     - include: razor-keywords-html-attribute-single-quoted
+  tag-generic-attribute-value-unquoted-content:
+    - meta_prepend: true
+    - include: razor-keywords-html-attribute-unquoted

--- a/syntax/Razor C#.sublime-syntax
+++ b/syntax/Razor C#.sublime-syntax
@@ -79,11 +79,15 @@ contexts:
     # Razor keywords that switch to C# default.
     - match: '\@(?={{razor_keywords}})'
       scope: keyword.other.reserved.razor
-      push: [immediately-pop-cs, scope:source.razor.engine#keyword]
+      push:
+        - immediately-pop-cs
+        - scope:source.razor.engine#keyword
     # Inline C# expressions.
     - match: '\@'
       scope: keyword.other.expression.razor
-      push: [immediately-pop-cs, scope:embed.source.cs.razor#razor-expression-eol]
+      push:
+        - immediately-pop-cs
+        - scope:embed.source.cs.razor#razor-expression-eol
 
   # When inside an HTML attribute, we need special handling to deal with switching back to HTML.
   # We also need to clear the string scope.
@@ -91,11 +95,15 @@ contexts:
   razor-keywords-html-attribute-single-quoted:
     - match: '\@'
       scope: keyword.other.expression.razor
-      push: [immediately-pop-cs-clear-string-scope, scope:embed.source.cs.razor#razor-single-quote-expression]
+      push:
+        - immediately-pop-cs-clear-string-scope
+        - scope:embed.source.cs.razor#razor-single-quote-expression
   razor-keywords-html-attribute-double-quoted:
     - match: '\@'
       scope: keyword.other.expression.razor
-      push: [immediately-pop-cs-clear-string-scope, scope:embed.source.cs.razor#razor-double-quote-expression]
+      push:
+        - immediately-pop-cs-clear-string-scope
+        - scope:embed.source.cs.razor#razor-double-quote-expression
 
   # Enable Razor context switching.
   tag-html:
@@ -111,27 +119,37 @@ contexts:
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.block.any.html
-      set: [tag-html-nested-end, block-any-tag-content]
+      set:
+        - tag-html-nested-end
+        - block-any-tag-content
     - match: (<)({{html_inline_tags}})
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.inline.any.html
-      set: [tag-html-nested-end, inline-any-tag-content]
+      set:
+        - tag-html-nested-end
+        - inline-any-tag-content
     - match: (<)((?i:form|fieldset){{tag_name_break}})
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.block.form.html
-      set: [tag-html-nested-end, block-forms-tag-content]
+      set:
+        - tag-html-nested-end
+        - block-forms-tag-content
     - match: (<)({{html_forms_tags}})
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.inline.form.html
-      set: [tag-html-nested-end, inline-forms-tag-content]
+      set:
+        - tag-html-nested-end
+        - inline-forms-tag-content
     - match: (<)({{html_table_tags}})
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.inline.table.html
-      set: [tag-html-nested-end, table-tag-content]
+      set:
+        - tag-html-nested-end
+        - table-tag-content
 
   # Special nested syntax for templated delegates.
   tag-html-nested-end:

--- a/syntax/Razor C#.sublime-syntax
+++ b/syntax/Razor C#.sublime-syntax
@@ -25,7 +25,7 @@ variables:
 
   razor_html_default: '(?xi: section)'
 
-# This syntax uses embed.text.html and embed.source.cs as scope names.
+# This syntax uses embed.text.html.razor, embed.text.css.razor, and embed.source.cs.razor as scope names.
 # While not considered proper, this is done to ensure comments work.
 # Without it, comments that start in one language and end in the other won't work properly.
 # This is due to conflicts with the built-in comments assigned to text.html.basic and source.cs.
@@ -38,19 +38,19 @@ contexts:
 
   main:
     - meta_prepend: true
-    - meta_scope: embed.text.html
+    - meta_scope: embed.text.html.razor
     - include: razor-comments
 
   # Used to apply a meta scope to the C# syntax.
   immediately-pop-cs:
     - meta_include_prototype: false
-    - meta_scope: embed.source.cs
+    - meta_scope: embed.source.cs.razor
     - match: ''
       pop: 1
   immediately-pop-cs-clear-string-scope:
     - clear_scopes: 1
     - meta_include_prototype: false
-    - meta_scope: embed.source.cs
+    - meta_scope: embed.source.cs.razor
     - match: ''
       pop: 1
 
@@ -75,17 +75,17 @@ contexts:
   razor-keywords:
     # Razor keywords that keep the block in HTML mode.
     - match: '\@(?={{razor_html_default}})'
-      scope: punctuation.definition.keyword.razor
+      scope: punctuation.definition.embedded.razor
       set: scope:source.razor.engine#keyword
     # Razor keywords that switch to C# default.
     - match: '\@(?={{razor_keywords}})'
-      scope: punctuation.definition.keyword.razor
+      scope: punctuation.definition.embedded.razor
       push:
         - immediately-pop-cs
         - scope:source.razor.engine#keyword
     # Inline C# expressions.
     - match: '\@'
-      scope: punctuation.definition.keyword.razor
+      scope: punctuation.definition.embedded.razor
       push:
         - immediately-pop-cs
         - scope:embed.source.cs.razor#razor-expression-implicit
@@ -95,7 +95,7 @@ contexts:
   # Inline C# expressions only.
   razor-keywords-html-attribute-single-quoted:
     - match: '\@'
-      scope: punctuation.definition.keyword.razor
+      scope: punctuation.definition.embedded.razor
       push:
         - match: (?={{razor_keywords}})
           set:
@@ -107,7 +107,7 @@ contexts:
             - scope:embed.source.cs.razor#razor-single-quote-expression
   razor-keywords-html-attribute-double-quoted:
     - match: '\@'
-      scope: punctuation.definition.keyword.razor
+      scope: punctuation.definition.embedded.razor
       push:
         - match: (?={{razor_keywords}})
           set:
@@ -119,7 +119,7 @@ contexts:
             - scope:embed.source.cs.razor#razor-double-quote-expression
   razor-keywords-html-attribute-unquoted:
     - match: '\@'
-      scope: punctuation.definition.keyword.razor
+      scope: punctuation.definition.embedded.razor
       push:
         - match: (?={{razor_keywords}})
           set:
@@ -132,13 +132,13 @@ contexts:
 
   # Enable Razor context switching.
   tag-html:
-    - meta_scope: embed.text.html
+    - meta_scope: embed.text.html.razor
     - meta_prepend: true
     - include: razor-keywords
 
   # Special nested syntax for templated delegates.
   tag-html-nested-start:
-    - meta_scope: embed.text.html
+    - meta_scope: embed.text.html.razor
     - include: razor-keywords
     - match: (<)({{html_block_tags}})
       captures:
@@ -183,7 +183,7 @@ contexts:
 
   # Special nested syntax for templated delegates.
   tag-html-nested-end:
-    - meta_scope: embed.text.html
+    - meta_scope: embed.text.html.razor
     - include: razor-keywords
     - match: '(</)({{tag_name}})(>)'
       captures:
@@ -197,7 +197,7 @@ contexts:
 
   # Properly pop back to C# mode when we encounter an end tag (handled in tag-end-razor)
   tag-html-embed:
-    - meta_scope: embed.text.html
+    - meta_scope: embed.text.html.razor
     - include: razor-comments
     - match: '(</)({{html_block_tags}}|{{html_inline_tags}})'
       captures:

--- a/syntax/Razor C#.sublime-syntax
+++ b/syntax/Razor C#.sublime-syntax
@@ -268,3 +268,47 @@ contexts:
   tag-generic-attribute-value-unquoted-content:
     - meta_prepend: true
     - include: razor-keywords-html-attribute-unquoted
+
+  style-css-content:
+    - meta_include_prototype: false
+    - match: \s*((<!\[)(CDATA)(\[))
+      captures:
+        1: meta.tag.sgml.cdata.html
+        2: punctuation.definition.tag.begin.html
+        3: keyword.declaration.cdata.html
+        4: punctuation.definition.tag.begin.html
+      pop: 1  # make sure to match only once
+      embed: scope:embed.text.css.razor
+      embed_scope: meta.tag.sgml.cdata.html source.css.embedded.html
+      escape: \]\]>
+      escape_captures:
+        0: meta.tag.sgml.cdata.html punctuation.definition.tag.end.html
+    - match: '{{style_content_begin}}'
+      captures:
+        1: comment.block.html punctuation.definition.comment.begin.html
+      pop: 1  # make sure to match only once
+      embed: scope:embed.text.css.razor
+      embed_scope: source.css.embedded.html
+      escape: '{{style_content_end}}'
+      escape_captures:
+        1: source.css.embedded.html
+        2: comment.block.html punctuation.definition.comment.end.html
+        3: source.css.embedded.html
+        4: comment.block.html punctuation.definition.comment.end.html
+
+  tag-style-attribute-value:
+    - match: \"
+      scope: meta.string.html string.quoted.double.html punctuation.definition.string.begin.html
+      embed: scope:embed.text.css.razor#rule-list-body
+      embed_scope: meta.string.html source.css.embedded.html
+      escape: \"
+      escape_captures:
+        0: meta.string.html string.quoted.double.html punctuation.definition.string.end.html
+    - match: \'
+      scope: meta.string.html string.quoted.single.html punctuation.definition.string.begin.html
+      embed: scope:embed.text.css.razor#rule-list-body
+      embed_scope: meta.string.html source.css.embedded.html
+      escape: \'
+      escape_captures:
+        0: meta.string.html string.quoted.single.html punctuation.definition.string.end.html
+    - include: else-pop

--- a/tests/syntax_test_Razor_C#.cshtml
+++ b/tests/syntax_test_Razor_C#.cshtml
@@ -62,7 +62,9 @@
 </form>
 
 <link rel="stylesheet" href="@Assets["BlazorApp.styles.css"]" />
-<div id='@MyClass.MyId' class='theclass-@name' custom="custom-@(value)"></div>
+<div id='@MyClass.MyId' class='theclass-@name' custom='custom-@(value)'></div>
+<div id="@MyClass.MyId" class="theclass-@name" custom="custom-@(value)"></div>
+<div id=@MyClass.MyId class=theclass-@name custom=custom-@(value)></div>
 
 <link href="@Url.Content("~/Styles/main.css")" rel="stylesheet" type="text/css" />
 

--- a/tests/syntax_test_Razor_C#.cshtml
+++ b/tests/syntax_test_Razor_C#.cshtml
@@ -194,6 +194,13 @@ else
     var i = true;
 }
 
+@if (true)
+{
+    var i = 1;
+}
+else for (var j = 0; j < 10; ++j)
+    ViewData[$"Test{j}"] = $"Test{j}";
+
 <p style="display: none">Test</p>
 
 @switch (DateTime.Now.Year)

--- a/tests/syntax_test_Razor_C#.cshtml
+++ b/tests/syntax_test_Razor_C#.cshtml
@@ -1,6 +1,6 @@
 @* SYNTAX TEST "Razor C#.sublime-syntax" *@
 @attribute [Authorize]
-@* <- source.razor embed.text.html embed.source.cs punctuation.definition.keyword.razor *@
+@* <- source.razor embed.text.html embed.source.cs punctuation.definition.embedded.razor *@
 @* ^^^^^^^             keyword.other.attribute.razor *@
 @*         ^^^^^^^^^^^ meta.annotation *@
 
@@ -135,41 +135,41 @@
 @* ^                  punctuation.definition.tag.begin.html *@
 @* ^^                 meta.tag.block.any.html *@
 @*  ^                 entity.name.tag.block.any.html *@
-@*    ^               punctuation.definition.keyword.razor *@
+@*    ^               punctuation.definition.embedded.razor *@
 @*     ^^^^^^^^^^     meta.attribute-with-value.style.html keyword.other.attribute-bind.razor *@
 @*                  ^ meta.annotation.cs variable.annotation.cs *@
 
 <label>InputValue:<input @bind="InputValue" @bind:culture="new CultureInfo("th-TH", false)" /></label>
-@*                       ^                                    punctuation.definition.keyword.razor *@
+@*                       ^                                    punctuation.definition.embedded.razor *@
 @*                        ^^^^                                keyword.other.attribute-bind.razor *@
 @*                               ^                            variable.other.cs *@
 @*                                           ^^^^^^^^^^^^     keyword.other.attribute-bind.razor *@
 @*                                                          ^ meta.instantiation.cs keyword.operator.new.cs *@
 
 <form method="post" @formname="starship-plain-form" @onsubmit="Submit" @onclick:preventDefault>
-@*                  ^             punctuation.definition.keyword.razor *@
+@*                  ^             punctuation.definition.embedded.razor *@
 @*                   ^^^^^^^^     keyword.other.attribute-bind.razor *@
 @*                              ^ meta.string.html string.quoted.double.html *@
-@*                                                  ^             punctuation.definition.keyword.razor *@
+@*                                                  ^             punctuation.definition.embedded.razor *@
 @*                                                   ^^^^^^^^     keyword.other.attribute-bind.razor *@
 @*                                                              ^ variable.other.cs *@
-@*                                                                     ^          punctuation.definition.keyword.razor *@
+@*                                                                     ^          punctuation.definition.embedded.razor *@
 @*                                                                      ^^^^^^^   keyword.other.attribute-bind.razor *@
 @*                                                                             ^  punctuation.separator.event.html *@
 @*                                                                              ^ entity.other.attribute-name.html *@
     <AntiforgeryToken />
     <ReferenceChild @ref="childComponent1" @rendermode='InteractiveAuto' />
-@*                  ^        punctuation.definition.keyword.razor *@
+@*                  ^        punctuation.definition.embedded.razor *@
 @*                   ^^^     keyword.other.attribute-bind.razor *@
 @*                         ^ variable.other.cs *@
-@*                                         ^               punctuation.definition.keyword.razor *@
+@*                                         ^               punctuation.definition.embedded.razor *@
 @*                                          ^^^^^^^^^^     keyword.other.rendermode.razor *@
 @*                                                       ^ constant.language.rendermode.razor *@
     <div>
         <label>
             Identifier:
             <InputText @bind-Value="Model!.Id" />
-@*                     ^               punctuation.definition.keyword.razor *@
+@*                     ^               punctuation.definition.embedded.razor *@
 @*                      ^^^^^^^^^^     keyword.other.attribute-bind.razor *@
 @*                                   ^ variable.other.cs *@
         </label>
@@ -180,36 +180,36 @@
 </form>
 
 <link rel="stylesheet" href="@Assets["BlazorApp.styles.css"]" />
-@*                           ^   punctuation.definition.keyword.razor *@
+@*                           ^   punctuation.definition.embedded.razor *@
 @*                             ^ variable.other.cs *@
 <div id='@MyClass.MyId' class='theclass-@name' custom='custom-@(var)'></div>
 @*      ^    meta.string.html string.quoted.single.html punctuation.definition.string.begin.html *@
-@*       ^   punctuation.definition.keyword.razor *@
+@*       ^   punctuation.definition.embedded.razor *@
 @*         ^ variable.other.cs *@
 @*                             ^^^^^^^^^      meta.string.html string.quoted.single.html *@
-@*                                      ^     punctuation.definition.keyword.razor *@
+@*                                      ^     punctuation.definition.embedded.razor *@
 @*                                       ^^^^ variable.other.cs *@
 @*                                                     ^^^^^^^     meta.string.html string.quoted.single.html *@
-@*                                                            ^    punctuation.definition.keyword.razor *@
+@*                                                            ^    punctuation.definition.embedded.razor *@
 @*                                                             ^   keyword.other.inline.begin.razor *@
 @*                                                               ^ variable.other.cs *@
 <div id="@MyClass.MyId" class="theclass-@name" custom="custom-@(var)"></div>
 @*      ^    meta.string.html string.quoted.double.html punctuation.definition.string.begin.html *@
-@*       ^   punctuation.definition.keyword.razor *@
+@*       ^   punctuation.definition.embedded.razor *@
 @*         ^ variable.other.cs *@
 @*                                                     ^^^^^^^     meta.string.html string.quoted.double.html *@
-@*                                                            ^    punctuation.definition.keyword.razor *@
+@*                                                            ^    punctuation.definition.embedded.razor *@
 @*                                                             ^   keyword.other.inline.begin.razor *@
 @*                                                               ^ variable.other.cs *@
 <div id=@MyClass.MyId class=theclass-@name custom=custom-@(var)></div>
-@*      ^   string.unquoted.html punctuation.definition.keyword.razor *@
+@*      ^   string.unquoted.html punctuation.definition.embedded.razor *@
 @*        ^ variable.other.cs *@
 @*                                                ^^^^^^^     meta.string.html string.unquoted.html *@
-@*                                                       ^    punctuation.definition.keyword.razor *@
+@*                                                       ^    punctuation.definition.embedded.razor *@
 @*                                                        ^   keyword.other.inline.begin.razor *@
 @*                                                          ^ variable.other.cs *@
 <link href="@Url.Content("~/Styles/main.css")" rel="stylesheet" type="text/css" />
-@*          ^       punctuation.definition.keyword.razor *@
+@*          ^       punctuation.definition.embedded.razor *@
 @*            ^     variable.other.cs *@
 @*                ^ meta.function-call.identifier.cs variable.function.cs *@
 
@@ -239,7 +239,7 @@
 @*                          ^^ comment.block.razor punctuation.definition.comment.end.razor *@
 
     @variable.whatever(x => { x < 10 })<p>Okay</p>
-@*  ^                                      punctuation.definition.keyword.razor *@
+@*  ^                                      punctuation.definition.embedded.razor *@
 @*    ^                                    variable.other.cs *@
 @*             ^                           variable.function.cs *@
 @*                     ^                   meta.function.anonymous.parameters.cs variable.parameter.cs *@
@@ -248,7 +248,7 @@
 @*                                     ^^^ meta.tag.block.any.html *@
 
     @if (test == 1) {
-@*  ^                 punctuation.definition.keyword.razor *@
+@*  ^                 punctuation.definition.embedded.razor *@
 @*   ^^               keyword.control.conditional.if.cs *@
 @*                  ^ meta.block.cs punctuation.section.block.begin.cs *@
         int i = a;
@@ -256,7 +256,7 @@
     }
 
     @using (var service = GetService()) {
-@*  ^                        punctuation.definition.keyword.razor *@
+@*  ^                        punctuation.definition.embedded.razor *@
 @*   ^^^^^                   keyword.declaration.using.cs *@
 @*                         ^ variable.function.cs *@
         int i = a;
@@ -265,7 +265,7 @@
 }
 
    @{
-@* ^  punctuation.definition.keyword.razor *@
+@* ^  punctuation.definition.embedded.razor *@
 @*  ^ punctuation.section.block.begin.razor keyword.other.block.razor *@
     #region Test Region
     string[] teamMembers = {"Matt", "Joanne", "Robert", "Nancy"};
@@ -275,17 +275,18 @@
 @*  ^^^ comment.block.razor *@
     <p>The number of names in the teamMembers array: @teamMembers.Length</p>
 @*  ^^^                                                                      meta.tag.block.any.html *@
-@*                                                   ^                       punctuation.definition.keyword.razor *@
+@*                                                   ^                       punctuation.definition.embedded.razor *@
 @*                                                     ^                     variable.other.cs *@
+@*                                                                 ^         variable.other.cs *@
 @*                                                                      ^^^^ meta.tag.block.any.html *@
     <p>The number of names in the teamMembers array: @teamMembers.Length </p>
 @*                                                                      ^     embed.text.html *@
 @*                                                                       ^^^^ meta.tag.block.any.html *@
     @:Raw HTML line test @teamMembers.Length
-@*  ^                                    punctuation.definition.keyword.razor *@
+@*  ^                                    punctuation.definition.embedded.razor *@
 @*   ^                                   keyword.other.embed.html.razor *@
 @*     ^                                 embed.text.html *@
-@*                       ^               punctuation.definition.keyword.razor *@
+@*                       ^               punctuation.definition.embedded.razor *@
 @*                         ^             variable.other.cs *@
 @*                                     ^ variable.other.cs *@
 
@@ -299,7 +300,7 @@
         var name2 = "(U) " + name;
         <p>@name.Select(x => x.ToUpper())</p>
 @*      ^^^                                   meta.tag.block.any.html *@
-@*         ^                                  punctuation.definition.keyword.razor *@
+@*         ^                                  punctuation.definition.embedded.razor *@
 @*           ^                                variable.other.cs *@
 @*                ^                           variable.function.cs *@
 @*                                       ^^^^ meta.tag.block.any.html *@
@@ -312,7 +313,7 @@
             Reversed
 @*          ^   embed.text.html *@
             @reversedItem
-@*          ^   punctuation.definition.keyword.razor *@
+@*          ^   punctuation.definition.embedded.razor *@
 @*            ^ variable.other.cs *@
         </text>
 @*        ^^^^ entity.name.tag.html *@
@@ -321,9 +322,9 @@
 
 @{
     Func<dynamic, object> petTemplate = @<p>You have a pet named <strong>@item.Name</strong>.</p>;
-@*                                      ^                                                          punctuation.definition.keyword.razor *@
+@*                                      ^                                                          punctuation.definition.embedded.razor *@
 @*                                       ^^^                                                       meta.tag.block.any.html *@
-@*                                                                       ^                         punctuation.definition.keyword.razor *@
+@*                                                                       ^                         punctuation.definition.embedded.razor *@
 @*                                                                         ^                       variable.other.cs *@
 @*                                                                                           ^^^^  meta.tag.block.any.html *@
 @*                                                                                               ^ punctuation.terminator.statement.cs *@
@@ -349,7 +350,7 @@
 @foreach (var myItem in Request.ServerVariables)
 {
     @:<li>My item is @myItem.Test()
-@*  ^      punctuation.definition.keyword.razor *@
+@*  ^      punctuation.definition.embedded.razor *@
 @*   ^     keyword.other.embed.html.razor *@
 @*    ^^^^ meta.tag.block.any.html *@
 @*                            ^ variable.function.cs *@
@@ -372,7 +373,7 @@
 
 <!-- Implicit expressions should not contain spaces, except after await or when the C# statement has a clear ending -->
 <p>@await DoSomething("hello", "world")</p>
-@* ^                                        punctuation.definition.keyword.razor *@
+@* ^                                        punctuation.definition.embedded.razor *@
 @*  ^^^^^                                   keyword.control.flow.await.cs *@
 @*        ^^^^^^^^^^^                       variable.function.cs *@
 @*                     ^^^^^                meta.string.cs string.quoted.double.cs *@
@@ -383,7 +384,7 @@
 @*             ^^^^^^^^^^^^^^^ meta.email *@
 
 <p>The book is ISBN@(isbnNumber)</p>
-@*                 ^              punctuation.definition.keyword.razor *@
+@*                 ^              punctuation.definition.embedded.razor *@
 @*                  ^             keyword.other.inline.begin.razor *@
 @*                    ^           variable.other.cs *@
 @*                             ^  keyword.other.inline.end.razor *@
@@ -416,7 +417,7 @@
         the date: @DateTime.Now
     </text>
 
-    @* BUG: The style should highlight but it doesn't.  Most likely not fixable. *@
+    @* BUG: The style should highlight but it doesn't.  Most likely not fixable without introducing recursion. *@
     <p @if (true) { <text>style="display: none"</text> }>Test</p>
 }
 else if (DateTime.Now.Year == 2011)
@@ -501,24 +502,28 @@ while(true)
     }
 } catch {
 @* ^ keyword.control.exception.catch.cs *@
+@* <- meta.block.cs *@
     var t = true;
     <p>catch</p>
 }
 catch (Exception e)
 @* ^ keyword.control.exception.catch.cs *@
 {
+@* <- meta.block.cs *@
     var t = false;
     <div>catch e</div>
 }
 finally
 @* ^ keyword.control.exception.finally.cs *@
 {
+@* <- meta.block.cs *@
     var t = true;
 }
 
 @lock (SomeLock)
 @* ^ keyword.control.flow.lock.cs *@
 {
+@* <- meta.block.cs *@
     // Do critical section work
 }
 

--- a/tests/syntax_test_Razor_C#.cshtml
+++ b/tests/syntax_test_Razor_C#.cshtml
@@ -529,5 +529,9 @@ finally
 
 <style>
 @media {}
-@* BUG: This should probably work. *@
+   @* Comment inside a style tag. *@
+@* ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.razor *@
 </style>
+
+<span style="display: none; @* Comment in style attribute *@"></span>
+@*                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.razor *@

--- a/tests/syntax_test_Razor_C#.cshtml
+++ b/tests/syntax_test_Razor_C#.cshtml
@@ -8,9 +8,9 @@
 }
 
 @implements IDisposable
-@implements namespace.IDisposable
+@implements mynamespace.IDisposable
 
-@inherits Namespace.CustomRazorPage<TModel>
+@inherits MyNamespace.CustomRazorPage<TModel>
 @inject IMyService MyService
 @namespace Your.Namespace.Here
 
@@ -63,6 +63,8 @@
 
 <link rel="stylesheet" href="@Assets["BlazorApp.styles.css"]" />
 <div id='@MyClass.MyId' class='theclass'></div>
+
+<link href="@Url.Content("~/Styles/main.css")" rel="stylesheet" type="text/css" />
 
 @section test {
 

--- a/tests/syntax_test_Razor_C#.cshtml
+++ b/tests/syntax_test_Razor_C#.cshtml
@@ -62,7 +62,7 @@
 </form>
 
 <link rel="stylesheet" href="@Assets["BlazorApp.styles.css"]" />
-<div id='@MyClass.MyId' class='theclass'></div>
+<div id='@MyClass.MyId' class='theclass-@name' custom="custom-@(value)"></div>
 
 <link href="@Url.Content("~/Styles/main.css")" rel="stylesheet" type="text/css" />
 

--- a/tests/syntax_test_Razor_C#.cshtml
+++ b/tests/syntax_test_Razor_C#.cshtml
@@ -1,59 +1,177 @@
+@* SYNTAX TEST "Razor C#.sublime-syntax" *@
 @attribute [Authorize]
+@* <- source.razor embed.text.html embed.source.cs punctuation.definition.keyword.razor *@
+@* ^^^^^^^             keyword.other.attribute.razor *@
+@*         ^^^^^^^^^^^ meta.annotation *@
 
 @functions {
+@* ^^^^^^^ keyword.other.code.block.razor *@
+@*         ^ punctuation.section.block.begin.razor keyword.other.block.razor *@
+
+@* <- embed.source.cs meta.block.cs *@
     public string GetHello()
+@*    ^ meta.block storage.modifier.access *@
     {
+@*  ^ meta.block.cs punctuation.section.block.begin.cs *@
         return "Hello";
     }
 }
+@* <- punctuation.section.block.end.razor keyword.other.block.razor *@
 
 @implements IDisposable
+@* ^ keyword.other.implements.razor *@
+@*            ^ support.type.cs *@
 @implements mynamespace.IDisposable
-
+@*          ^^^^^^^^^^^             support.type.cs *@
+@*                     ^            punctuation.accessor.dot.cs *@
+@*                      ^^^^^^^^^^^ support.type.cs *@
 @inherits MyNamespace.CustomRazorPage<TModel>
+@* ^ keyword.other.inherits.razor *@
+@*        ^^^^^^^^^^^                  support.type.cs *@
+@*                   ^                 punctuation.accessor.dot.cs *@
+@*                                   ^ punctuation.definition.generic.begin.cs *@
 @inject IMyService MyService
+@* ^                  keyword.other.inject.razor *@
+@*       ^            entity.name.interface.cs *@
+@*                  ^ variable.other.cs *@
 @namespace Your.Namespace.Here
+@* ^                           keyword.other.namespace.razor *@
+@*         ^^^^                variable.namespace.cs *@
+@*             ^               punctuation.accessor.dot.cs *@
+@*                        ^^^^ entity.name.namespace.cs *@
 
 @page
+@* ^ keyword.other.page.razor *@
 @page "/resource/{text?}"
+@*    ^^^^^^^^^^^^^^^^^^^ string.quoted.double.cs *@
+@*    ^                   punctuation.definition.string.begin.cs *@
+@*                      ^ punctuation.definition.string.end.cs *@
 @page "{id:int}"
 
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@* ^                                  keyword.other.taghelper.razor *@
+@*            ^                       constant.other.wildcard.asterisk.razor *@
+@*             ^                      punctuation.definition.separator.fqn *@
+@*               ^^^^^^^^^            variable.namespace.cs *@
+@*                        ^           punctuation.accessor.dot.cs *@
+@*                         ^^^^^^^^^^ variable.namespace.cs *@
 @addTagHelper MyAssembly*, MyAssembly.Whatever
+@*            ^^^^^^^^^^  variable.other.cs *@
+@*                      ^ constant.other.wildcard.asterisk.razor *@
+
 @removeTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@* ^                                     keyword.other.taghelper.razor *@
+@*               ^                       constant.other.wildcard.asterisk.razor *@
+@*                ^                      punctuation.definition.separator.fqn *@
+@*                  ^^^^^^^^^            variable.namespace.cs *@
+@*                           ^           punctuation.accessor.dot.cs *@
+@*                            ^^^^^^^^^^ variable.namespace.cs *@
 @removeTagHelper MyAssembly*, MyAssembly.Whatever
+@*               ^^^^^^^^^^  variable.other.cs *@
+@*                         ^ constant.other.wildcard.asterisk.razor *@
+
 @tagHelperPrefix th:
+@* ^                 keyword.other.taghelper.razor *@
+@*               ^^^ entity.name.tag.prefix.razor *@
 
 @model MyApp.Models.MyModel
+@* ^          keyword.other.model.razor *@
+@*     ^^^^^  support.type.cs *@
+@*          ^ punctuation.accessor.dot.cs *@
+
 @using MyApp.Models
+@* ^          keyword.other.using.razor *@
+@*     ^^^^^  variable.namespace.cs *@
+@*          ^ punctuation.accessor.dot.cs *@
 
 @preservewhitespace true
+@* ^                     keyword.other.preservewhitespace.razor *@
+@*                  ^^^^ constant.language.cs *@
 @preservewhitespace
 @preservewhitespace false
+@* ^                      keyword.other.preservewhitespace.razor *@
+@*                  ^^^^^ constant.language.cs *@
 @rendermode InteractiveWebAssembly
+@* ^           keyword.other.rendermode.razor *@
+@*           ^ constant.language.rendermode.razor *@
+@rendermode InteractiveServer
+@*           ^ constant.language.rendermode.razor *@
+@rendermode InteractiveAuto
+@*           ^ constant.language.rendermode.razor *@
+@rendermode RenderMode.InteractiveAuto
+@*           ^ constant.language.rendermode.razor *@
+@rendermode Something
+@*           ^ embed.text.html *@
 
 @layout DoctorWhoLayout
+@* ^       keyword.other.layout.razor *@
+@*       ^ support.type.cs *@
 
 @code { public string MyString; }
+@* ^                              keyword.other.code.block.razor *@
+@*    ^                           punctuation.section.block.begin.razor keyword.other.block.razor *@
+@*       ^                        storage.modifier.access.cs *@
+@*                              ^ punctuation.section.block.end.razor keyword.other.block.razor *@
 @code{ public string MyString; }
+@*   ^     punctuation.section.block.begin.razor keyword.other.block.razor *@
 @code
+@* ^       keyword.other.code.block.razor *@
 {
+@* <-      punctuation.section.block.begin.razor keyword.other.block.razor *@
     public string MyString;
+@*   ^     storage.modifier.access.cs *@
 }
 
 @typeparam TEntity
+@* ^          keyword.other.typeparam.razor *@
+@*          ^ meta.constraints.cs entity.name.interface.cs *@
 @typeparam TEntity where TEntity : IEntity
+@*                  ^                 meta.constraints.cs storage.modifier.where.cs *@
+@*                        ^           support.type.cs *@
+@*                               ^    punctuation.separator.colon.cs *@
+@*                                  ^ support.type.cs *@
 
-<p @attributes="Stuff"></p>
+   <p @attributes="Stuff"></p>
+@* ^                  punctuation.definition.tag.begin.html *@
+@* ^^                 meta.tag.block.any.html *@
+@*  ^                 entity.name.tag.block.any.html *@
+@*    ^               punctuation.definition.keyword.razor *@
+@*     ^^^^^^^^^^     meta.attribute-with-value.style.html keyword.other.attribute-bind.razor *@
+@*                  ^ meta.annotation.cs variable.annotation.cs *@
+
 <label>InputValue:<input @bind="InputValue" @bind:culture="new CultureInfo("th-TH", false)" /></label>
+@*                       ^                                    punctuation.definition.keyword.razor *@
+@*                        ^^^^                                keyword.other.attribute-bind.razor *@
+@*                               ^                            variable.other.cs *@
+@*                                           ^^^^^^^^^^^^     keyword.other.attribute-bind.razor *@
+@*                                                          ^ meta.instantiation.cs keyword.operator.new.cs *@
 
 <form method="post" @formname="starship-plain-form" @onsubmit="Submit" @onclick:preventDefault>
+@*                  ^             punctuation.definition.keyword.razor *@
+@*                   ^^^^^^^^     keyword.other.attribute-bind.razor *@
+@*                              ^ meta.string.html string.quoted.double.html *@
+@*                                                  ^             punctuation.definition.keyword.razor *@
+@*                                                   ^^^^^^^^     keyword.other.attribute-bind.razor *@
+@*                                                              ^ variable.other.cs *@
+@*                                                                     ^          punctuation.definition.keyword.razor *@
+@*                                                                      ^^^^^^^   keyword.other.attribute-bind.razor *@
+@*                                                                             ^  punctuation.separator.event.html *@
+@*                                                                              ^ entity.other.attribute-name.html *@
     <AntiforgeryToken />
     <ReferenceChild @ref="childComponent1" @rendermode='InteractiveAuto' />
+@*                  ^        punctuation.definition.keyword.razor *@
+@*                   ^^^     keyword.other.attribute-bind.razor *@
+@*                         ^ variable.other.cs *@
+@*                                         ^               punctuation.definition.keyword.razor *@
+@*                                          ^^^^^^^^^^     keyword.other.rendermode.razor *@
+@*                                                       ^ constant.language.rendermode.razor *@
     <div>
         <label>
             Identifier:
             <InputText @bind-Value="Model!.Id" />
+@*                     ^               punctuation.definition.keyword.razor *@
+@*                      ^^^^^^^^^^     keyword.other.attribute-bind.razor *@
+@*                                   ^ variable.other.cs *@
         </label>
     </div>
     <div>
@@ -62,49 +180,117 @@
 </form>
 
 <link rel="stylesheet" href="@Assets["BlazorApp.styles.css"]" />
-<div id='@MyClass.MyId' class='theclass-@name' custom='custom-@(value)'></div>
-<div id="@MyClass.MyId" class="theclass-@name" custom="custom-@(value)"></div>
-<div id=@MyClass.MyId class=theclass-@name custom=custom-@(value)></div>
-
+@*                           ^   punctuation.definition.keyword.razor *@
+@*                             ^ variable.other.cs *@
+<div id='@MyClass.MyId' class='theclass-@name' custom='custom-@(var)'></div>
+@*      ^    meta.string.html string.quoted.single.html punctuation.definition.string.begin.html *@
+@*       ^   punctuation.definition.keyword.razor *@
+@*         ^ variable.other.cs *@
+@*                             ^^^^^^^^^      meta.string.html string.quoted.single.html *@
+@*                                      ^     punctuation.definition.keyword.razor *@
+@*                                       ^^^^ variable.other.cs *@
+@*                                                     ^^^^^^^     meta.string.html string.quoted.single.html *@
+@*                                                            ^    punctuation.definition.keyword.razor *@
+@*                                                             ^   keyword.other.inline.begin.razor *@
+@*                                                               ^ variable.other.cs *@
+<div id="@MyClass.MyId" class="theclass-@name" custom="custom-@(var)"></div>
+@*      ^    meta.string.html string.quoted.double.html punctuation.definition.string.begin.html *@
+@*       ^   punctuation.definition.keyword.razor *@
+@*         ^ variable.other.cs *@
+@*                                                     ^^^^^^^     meta.string.html string.quoted.double.html *@
+@*                                                            ^    punctuation.definition.keyword.razor *@
+@*                                                             ^   keyword.other.inline.begin.razor *@
+@*                                                               ^ variable.other.cs *@
+<div id=@MyClass.MyId class=theclass-@name custom=custom-@(var)></div>
+@*      ^   string.unquoted.html punctuation.definition.keyword.razor *@
+@*        ^ variable.other.cs *@
+@*                                                ^^^^^^^     meta.string.html string.unquoted.html *@
+@*                                                       ^    punctuation.definition.keyword.razor *@
+@*                                                        ^   keyword.other.inline.begin.razor *@
+@*                                                          ^ variable.other.cs *@
 <link href="@Url.Content("~/Styles/main.css")" rel="stylesheet" type="text/css" />
+@*          ^       punctuation.definition.keyword.razor *@
+@*            ^     variable.other.cs *@
+@*                ^ meta.function-call.identifier.cs variable.function.cs *@
 
 @section test {
-
+@* ^            keyword.other.section.razor *@
+@*       ^^^^   meta.section meta.toc-list variable.other.section.razor *@
+@*            ^ keyword.other.block.razor punctuation.block.begin.razor *@
     <text>
+@*   ^^^^  meta.tag.other.html entity.name.tag.other.html *@
         Some stuff
+@*       ^ embed.text.html *@
     </text>
     <p>Test</p>
     <div>
         <p>Some stuff</p>
     </div>
 }
+@* <- punctuation.section.block.end.razor keyword.other.block.razor *@
 
 @section header {
 
     <p>This is a test</p>
 
     @* Some type of comment *@
+@*  ^^                         comment.block.razor punctuation.definition.comment.begin.razor *@
+@*      ^                      comment.block.razor *@
+@*                          ^^ comment.block.razor punctuation.definition.comment.end.razor *@
 
     @variable.whatever(x => { x < 10 })<p>Okay</p>
+@*  ^                                      punctuation.definition.keyword.razor *@
+@*    ^                                    variable.other.cs *@
+@*             ^                           variable.function.cs *@
+@*                     ^                   meta.function.anonymous.parameters.cs variable.parameter.cs *@
+@*                              ^          keyword.operator.comparison.cs *@
+@*                                ^^       constant.numeric.value.cs *@
+@*                                     ^^^ meta.tag.block.any.html *@
 
     @if (test == 1) {
+@*  ^                 punctuation.definition.keyword.razor *@
+@*   ^^               keyword.control.conditional.if.cs *@
+@*                  ^ meta.block.cs punctuation.section.block.begin.cs *@
         int i = a;
+@*      ^^^           storage.type.primitive.cs *@
     }
 
     @using (var service = GetService()) {
+@*  ^                        punctuation.definition.keyword.razor *@
+@*   ^^^^^                   keyword.declaration.using.cs *@
+@*                         ^ variable.function.cs *@
         int i = a;
+@*      ^^^           storage.type.primitive.cs *@
     }
 }
 
-@{
+   @{
+@* ^  punctuation.definition.keyword.razor *@
+@*  ^ punctuation.section.block.begin.razor keyword.other.block.razor *@
     #region Test Region
     string[] teamMembers = {"Matt", "Joanne", "Robert", "Nancy"};
+@*  ^^^^^^ storage.type.primitive.cs *@
     <p>The number of na@* mes in the teamMembers array: @teamMembers.Length</p>
     <p>The number of na *@mes in the teamMembers array: @teamMembers.Length </p>
+@*  ^^^ comment.block.razor *@
     <p>The number of names in the teamMembers array: @teamMembers.Length</p>
+@*  ^^^                                                                      meta.tag.block.any.html *@
+@*                                                   ^                       punctuation.definition.keyword.razor *@
+@*                                                     ^                     variable.other.cs *@
+@*                                                                      ^^^^ meta.tag.block.any.html *@
     <p>The number of names in the teamMembers array: @teamMembers.Length </p>
+@*                                                                      ^     embed.text.html *@
+@*                                                                       ^^^^ meta.tag.block.any.html *@
     @:Raw HTML line test @teamMembers.Length
+@*  ^                                    punctuation.definition.keyword.razor *@
+@*   ^                                   keyword.other.embed.html.razor *@
+@*     ^                                 embed.text.html *@
+@*                       ^               punctuation.definition.keyword.razor *@
+@*                         ^             variable.other.cs *@
+@*                                     ^ variable.other.cs *@
+
     <p>Robert is now in position: @Array.IndexOf(teamMembers, "Robert")</p>
+@*                                        ^ variable.function.cs *@
     My.Namespace.Var i = 0;
     #endregion
 
@@ -112,21 +298,38 @@
     {
         var name2 = "(U) " + name;
         <p>@name.Select(x => x.ToUpper())</p>
+@*      ^^^                                   meta.tag.block.any.html *@
+@*         ^                                  punctuation.definition.keyword.razor *@
+@*           ^                                variable.other.cs *@
+@*                ^                           variable.function.cs *@
+@*                                       ^^^^ meta.tag.block.any.html *@
     }
     Array.Reverse(teamMembers);
     foreach (var reversedItem in teamMembers)
     {
         <text>
+@*       ^^^^  entity.name.tag.html *@
             Reversed
+@*          ^   embed.text.html *@
             @reversedItem
+@*          ^   punctuation.definition.keyword.razor *@
+@*            ^ variable.other.cs *@
         </text>
+@*        ^^^^ entity.name.tag.html *@
     }
 }
 
 @{
     Func<dynamic, object> petTemplate = @<p>You have a pet named <strong>@item.Name</strong>.</p>;
+@*                                      ^                                                          punctuation.definition.keyword.razor *@
+@*                                       ^^^                                                       meta.tag.block.any.html *@
+@*                                                                       ^                         punctuation.definition.keyword.razor *@
+@*                                                                         ^                       variable.other.cs *@
+@*                                                                                           ^^^^  meta.tag.block.any.html *@
+@*                                                                                               ^ punctuation.terminator.statement.cs *@
 
     var pets = new List<Pet>
+@*  ^^^ storage.type.variant.cs *@
     {
         new Pet { Name = "Rin Tin Tin" },
         new Pet { Name = "Mr. Bigglesworth" },
@@ -136,14 +339,20 @@
 
 @{
 <p style="display: none;" class='whatever'></p>
+@* <- meta.tag.block.any.html punctuation.definition.tag.begin.html *@
     var c = @<p>My paragraph</p>;
     Func<dynamic, object> b = @<strong>@item</strong>;
+@*  ^^^^ support.type.cs *@
 }
 
 <ul>
 @foreach (var myItem in Request.ServerVariables)
 {
     @:<li>My item is @myItem.Test()
+@*  ^      punctuation.definition.keyword.razor *@
+@*   ^     keyword.other.embed.html.razor *@
+@*    ^^^^ meta.tag.block.any.html *@
+@*                            ^ variable.function.cs *@
 }
 </ul>
 
@@ -161,16 +370,41 @@
 <p>@DateTime.Now</p>
 <p>@DateTime.IsLeapYear(2016)</p>
 
+<!-- Implicit expressions should not contain spaces, except after await or when the C# statement has a clear ending -->
 <p>@await DoSomething("hello", "world")</p>
+@* ^                                        punctuation.definition.keyword.razor *@
+@*  ^^^^^                                   keyword.control.flow.await.cs *@
+@*        ^^^^^^^^^^^                       variable.function.cs *@
+@*                     ^^^^^                meta.string.cs string.quoted.double.cs *@
+@*                                     ^^^^ meta.tag.block.any.html *@
 
+<!-- An @ inside an email address is not identified as a transition character -->
 <p>My email is example@example</p>
-<p>The book is ISBN@(isbnNumber)</p>
-<span>Escaped @@ symbol</span>
+@*             ^^^^^^^^^^^^^^^ meta.email *@
 
+<p>The book is ISBN@(isbnNumber)</p>
+@*                 ^              punctuation.definition.keyword.razor *@
+@*                  ^             keyword.other.inline.begin.razor *@
+@*                    ^           variable.other.cs *@
+@*                             ^  keyword.other.inline.end.razor *@
+@*                              ^ meta.tag.block.any.html punctuation.definition.tag.begin.html *@
+
+<span>Escaped @@ symbol</span>
+@*            ^^ constant.character.escape *@
+
+<!-- <int> should match as HTML -->
+<p>@GenericMethod<int>()</p>
+@*   ^                 variable.other.cs *@
+@*               ^^^^^ meta.tag.other.html *@
+
+<!-- <int> should match as a C# generic -->
 <p>@(GenericMethod<int>())</p>
+@*    ^                 variable.function.cs *@
+@*                ^^^^^ meta.generic.cs *@
 
 @if (true) {
     var test = true;
+@*  ^^^ storage.type.variant.cs *@
 }
 
 @if (DateTime.Now.Year == 2010)
@@ -186,10 +420,12 @@
     <p @if (true) { <text>style="display: none"</text> }>Test</p>
 }
 else if (DateTime.Now.Year == 2011)
+@* ^ keyword.control.conditional.elseif.cs *@
 {
     var x = true;
 }
 else
+@* ^ keyword.control.conditional.else.cs *@
 {
     var t = false;
     <p>Not 2010.</p>
@@ -201,14 +437,19 @@ else
     var i = 1;
 }
 else for (var j = 0; j < 10; ++j)
+@*    ^           keyword.control.loop.for.cs *@
     ViewData[$"Test{j}"] = $"Test{j}";
+@*    ^           variable.other.cs *@
+@*              ^ meta.string.interpolated.cs *@
 
 <p style="display: none">Test</p>
 
 @switch (DateTime.Now.Year)
 {
     case 2015:
+@*   ^      keyword.control.conditional.case.cs *@
         <p>It is 2015</p>
+@*      ^^^ meta.tag.block.any.html *@
         break;
     case 2016:
         <p>It is 2016</p>
@@ -218,25 +459,30 @@ else for (var j = 0; j < 10; ++j)
 
 @while (true)
 {
+@* <- meta.block.cs *@
     var t = true;
     <p>LOOP</p>
 }
 
 @do
 {
+@* <- meta.block.cs *@
     var t = true;
     <p>LOOP</p>
 }
 while(true)
+@* ^ keyword.control.loop.while.cs *@
 
 @foreach (var person in people)
 {
+@* <- meta.block.cs *@
     <p>Name: @person.Name</p>
     <p>Age: @person.Age</p>
 }
 
 @using (Html.BeginForm())
 {
+@* <- meta.block.cs *@
     <div>
         Email: <input type="email" id="Email" value="">
         <button>Register</button>
@@ -245,6 +491,7 @@ while(true)
 
 @try
 {
+@* <- meta.block.cs *@
     var t = true;
     if (true)
     {
@@ -253,20 +500,29 @@ while(true)
         @:<p>TRY</p>
     }
 } catch {
+@* ^ keyword.control.exception.catch.cs *@
     var t = true;
     <p>catch</p>
 }
 catch (Exception e)
+@* ^ keyword.control.exception.catch.cs *@
 {
     var t = false;
     <div>catch e</div>
 }
 finally
+@* ^ keyword.control.exception.finally.cs *@
 {
     var t = true;
 }
 
 @lock (SomeLock)
+@* ^ keyword.control.flow.lock.cs *@
 {
     // Do critical section work
 }
+
+<style>
+@media {}
+@* BUG: This should probably work. *@
+</style>


### PR DESCRIPTION
The C# syntax was rewritten to better align with modern Sublime Text syntax packages, fix bugs, and improve performance.
See: https://github.com/sublimehq/Packages/pull/4547

The new syntax doesn't track control flow as closely as it did before, which poses a challenge for us.  Statements that may be followed by blocks (or follow up statements, like an `else` after an `if`), keeps Razor in C# mode; however, all statements and blocks in the new syntax are handled via the same scope (`embedded-statements`), which prevents us from staying in C# mode until the statement is fully processed.  Because of that, we are forced to rewrite the `embedded-statements` scope.  This makes maintenance potentially more difficult (any new statements added to C# have to be explicitly supported), but there is no alternative solution.

This will close #6.