### PR TITLE
Fix quoted inline expression termination

### DIFF
--- a/syntax/Razor C# (CSharp).sublime-syntax
+++ b/syntax/Razor C# (CSharp).sublime-syntax
@@ -147,18 +147,16 @@ contexts:
   # Used for data binding in Razor components.
   razor-single-quote-expression:
     - include: razor-comments
-    - match: "(?=')"
-      scope: string.quoted.single.html punctuation.definition.string.end.html
+    - match: (?=')
       pop: 1
-    - match: '$\n?'
+    - match: $
       pop: 1
     - include: expression
   razor-double-quote-expression:
     - include: razor-comments
-    - match: '(?=\")'
-      scope: string.quoted.double.html punctuation.definition.string.end.html
+    - match: (?=")
       pop: 1
-    - match: '$\n?'
+    - match: $
       pop: 1
     - include: expression
 


### PR DESCRIPTION
1. Remove scope assignment from lookahead patterns which don't consume text.
2. Don't consume trailing newline to leave e.g. illegal highlighting to owning syntax.