### PR TITLE
Fix razor block punctuation scope

### DIFF
--- a/syntax/Razor C# (CSharp).sublime-syntax
+++ b/syntax/Razor C# (CSharp).sublime-syntax
@@ -167,7 +167,7 @@ contexts:
     - meta_scope: meta.block.cs
     # Pop at the end of the block so we transition back to HTML correctly.
     - match: '\}'
-      scope: keyword.other.block.razor punctuation.block.end.razor
+      scope: punctuation.section.block.end.razor
       pop: 1
     - include: inside-csharp-block
 

--- a/syntax/Razor C# (Razor).sublime-syntax
+++ b/syntax/Razor C# (Razor).sublime-syntax
@@ -69,7 +69,7 @@ contexts:
   # Insert a colored code block.
   cs-block:
     - match: '\{'
-      scope: keyword.other.block.razor punctuation.block.begin.razor
+      scope: punctuation.section.block.begin.razor
       set: scope:embed.source.cs.razor#inside-razor-csharp-block
 
   keyword:
@@ -172,7 +172,7 @@ contexts:
         2: meta.section meta.toc-list variable.other.section.razor
       set:
         - match: '\{'
-          scope: keyword.other.block.razor punctuation.block.begin.razor
+          scope: punctuation.section.block.begin.razor
           set: scope:source.razor#razor-section-block
 
   component-directive:

--- a/syntax/Razor C#.sublime-syntax
+++ b/syntax/Razor C#.sublime-syntax
@@ -187,7 +187,7 @@ contexts:
   # Special context to properly get us out of @section blocks.
   razor-section-block:
     - match: '\}'
-      scope: keyword.other.block.razor punctuation.block.end.razor
+      scope: punctuation.section.block.end.razor
       pop: 2
     - include: main
 


### PR DESCRIPTION
This commit ensures consistent scope of braces, surrounding code blocks.

Goal is same punctuation scope for both, Razor and C# blocks.