### PR TITLE
Fix punctuation scope

### DIFF
--- a/syntax/Razor C# (CSharp).sublime-syntax
+++ b/syntax/Razor C# (CSharp).sublime-syntax
@@ -135,9 +135,10 @@ contexts:
 
   # Variant of expression that handles just an expression and pops on ) or newlines.
   razor-expression-paren:
+    - meta_scope: meta.group.cs
     - include: razor-comments
     - match: '\)'
-      scope: keyword.other.inline.end.razor
+      scope: punctuation.section.group.end.razor
       pop: 1
     - match: '$\n?'
       pop: 1
@@ -215,7 +216,7 @@ contexts:
   expression-common:
     - meta_prepend: true
     - match: '\@(?=<)'
-      scope: keyword.other.embed.html.razor
+      scope: punctuation.section.embedded.html.razor
       push: scope:source.razor#tag-html-embed
 
   inside-csharp-block:
@@ -237,7 +238,7 @@ contexts:
     - match: '(?=<)'
       push: scope:source.razor#tag-html-embed
     - match: '\@\:'
-      scope: keyword.other.embed.html.razor
+      scope: punctuation.section.embedded.html.razor
       embed: scope:source.razor
       escape: '$\n?'
 
@@ -260,7 +261,7 @@ contexts:
     - match: '(?=<)'
       push: scope:source.razor#tag-html-embed
     - match: '\@\:'
-      scope: keyword.other.embed.html.razor
+      scope: punctuation.section.embedded.html.razor
       embed: scope:source.razor
       escape: '$\n?'
 
@@ -270,5 +271,5 @@ contexts:
     - meta_prepend: true
     - include: razor-comments
     - match: '\@(?=<)'
-      scope: keyword.other.embed.html.razor
+      scope: punctuation.section.embedded.html.razor
       push: scope:source.razor#tag-html-nested-start

--- a/syntax/Razor C# (Razor).sublime-syntax
+++ b/syntax/Razor C# (Razor).sublime-syntax
@@ -95,7 +95,7 @@ contexts:
       set: cs-block
 
     - match: '\('
-      scope: keyword.other.inline.begin.razor
+      scope: punctuation.section.group.begin.razor
       set: scope:embed.source.cs.razor#razor-expression-paren
 
   general-directive:

--- a/syntax/Razor C#.sublime-syntax
+++ b/syntax/Razor C#.sublime-syntax
@@ -74,17 +74,17 @@ contexts:
     - meta_scope: embed.source.cs
     # Razor keywords that keep the block in HTML mode.
     - match: '\@(?={{razor_html_default}})'
-      scope: keyword.other.reserved.razor
+      scope: punctuation.section.embedded.razor
       set: scope:source.razor.engine#keyword
     # Razor keywords that switch to C# default.
     - match: '\@(?={{razor_keywords}})'
-      scope: keyword.other.reserved.razor
+      scope: punctuation.section.embedded.razor
       push:
         - immediately-pop-cs
         - scope:source.razor.engine#keyword
     # Inline C# expressions.
     - match: '\@'
-      scope: keyword.other.expression.razor
+      scope: punctuation.section.embedded.razor
       push:
         - immediately-pop-cs
         - scope:embed.source.cs.razor#razor-expression-eol
@@ -94,13 +94,13 @@ contexts:
   # Inline C# expressions only.
   razor-keywords-html-attribute-single-quoted:
     - match: '\@'
-      scope: keyword.other.expression.razor
+      scope: punctuation.section.embedded.razor
       push:
         - immediately-pop-cs-clear-string-scope
         - scope:embed.source.cs.razor#razor-single-quote-expression
   razor-keywords-html-attribute-double-quoted:
     - match: '\@'
-      scope: keyword.other.expression.razor
+      scope: punctuation.section.embedded.razor
       push:
         - immediately-pop-cs-clear-string-scope
         - scope:embed.source.cs.razor#razor-double-quote-expression


### PR DESCRIPTION
This commit scopes `@` and `@(...)` punctuation `punctuation.section.embedded`, which is a common scope used in most template syntaxes.

To some degree internal ST functionality relies on proper `punctuation` scopes.

Note: `@(...)` is treated/scoped as embedded C# expression group.