### PR TITLE
Optimize cs-block

### DIFF
--- a/syntax/Razor C# (Razor).sublime-syntax
+++ b/syntax/Razor C# (Razor).sublime-syntax
@@ -91,8 +91,7 @@ contexts:
       scope: keyword.other.code.block.razor
       set: cs-block
 
-    - match: '(?=\{)'
-      set: cs-block
+    - include: cs-block
 
     - match: '\('
       scope: keyword.other.inline.begin.razor


### PR DESCRIPTION
This commit includes `cs-block` into `block` to avoid an unnecessary context switch. `cs-block` already sets its target context onto stack. Hence no need for an additional lookahead.