### PR TITLE
Fix inline embedding in generic HTML attribute values

### DIFF
--- a/syntax/Razor C# (CSharp).sublime-syntax
+++ b/syntax/Razor C# (CSharp).sublime-syntax
@@ -161,6 +161,11 @@ contexts:
     - match: '$\n?'
       pop: 1
     - include: expression
+  razor-unquoted-expression:
+    - match: (?=[\t\n\f ]|/?>)
+      pop: 1
+    - include: razor-comments
+    - include: expression
 
   # Formats braces.
   inside-razor-csharp-block:

--- a/syntax/Razor C#.sublime-syntax
+++ b/syntax/Razor C#.sublime-syntax
@@ -217,3 +217,10 @@ contexts:
   tag-id-attribute-value-single-quoted-content:
     - meta_prepend: true
     - include: razor-keywords-html-attribute-single-quoted
+
+  tag-generic-attribute-value-double-quoted-content:
+    - meta_prepend: true
+    - include: razor-keywords-html-attribute-double-quoted
+  tag-generic-attribute-value-single-quoted-content:
+    - meta_prepend: true
+    - include: razor-keywords-html-attribute-single-quoted

--- a/syntax/Razor C#.sublime-syntax
+++ b/syntax/Razor C#.sublime-syntax
@@ -43,11 +43,13 @@ contexts:
 
   # Used to apply a meta scope to the C# syntax.
   immediately-pop-cs:
+    - meta_include_prototype: false
     - meta_scope: embed.source.cs
     - match: ''
       pop: 1
   immediately-pop-cs-clear-string-scope:
     - clear_scopes: 1
+    - meta_include_prototype: false
     - meta_scope: embed.source.cs
     - match: ''
       pop: 1
@@ -104,6 +106,12 @@ contexts:
       push:
         - immediately-pop-cs-clear-string-scope
         - scope:embed.source.cs.razor#razor-double-quote-expression
+  razor-keywords-html-attribute-unquoted:
+    - match: '\@'
+      scope: punctuation.section.embedded.razor
+      push:
+        - immediately-pop-cs-clear-string-scope
+        - scope:embed.source.cs.razor#razor-unquoted-expression
 
   # Enable Razor context switching.
   tag-html:
@@ -203,6 +211,9 @@ contexts:
   tag-class-attribute-value-single-quoted-content:
     - meta_prepend: true
     - include: razor-keywords-html-attribute-single-quoted
+  tag-class-attribute-value-unquoted-content:
+    - meta_prepend: true
+    - include: razor-keywords-html-attribute-unquoted
 
   tag-href-attribute-value-double-quoted-content:
     - meta_prepend: true
@@ -210,6 +221,9 @@ contexts:
   tag-href-attribute-value-single-quoted-content:
     - meta_prepend: true
     - include: razor-keywords-html-attribute-single-quoted
+  tag-href-attribute-value-unquoted-content:
+    - meta_prepend: true
+    - include: razor-keywords-html-attribute-unquoted
 
   tag-id-attribute-value-double-quoted-content:
     - meta_prepend: true
@@ -217,6 +231,9 @@ contexts:
   tag-id-attribute-value-single-quoted-content:
     - meta_prepend: true
     - include: razor-keywords-html-attribute-single-quoted
+  tag-id-attribute-value-unquoted-content:
+    - meta_prepend: true
+    - include: razor-keywords-html-attribute-unquoted
 
   tag-generic-attribute-value-double-quoted-content:
     - meta_prepend: true
@@ -224,3 +241,6 @@ contexts:
   tag-generic-attribute-value-single-quoted-content:
     - meta_prepend: true
     - include: razor-keywords-html-attribute-single-quoted
+  tag-generic-attribute-value-unquoted-content:
+    - meta_prepend: true
+    - include: razor-keywords-html-attribute-unquoted

--- a/tests/syntax_test_Razor_C#.cshtml
+++ b/tests/syntax_test_Razor_C#.cshtml
@@ -62,7 +62,9 @@
 </form>
 
 <link rel="stylesheet" href="@Assets["BlazorApp.styles.css"]" />
-<div id='@MyClass.MyId' class='theclass-@name' custom="custom-@(value)"></div>
+<div id='@MyClass.MyId' class='theclass-@name' custom='custom-@(value)'></div>
+<div id="@MyClass.MyId" class="theclass-@name" custom="custom-@(value)"></div>
+<div id=@MyClass.MyId class=theclass-@name custom=custom-@(value)></div>
 
 <link href="@Url.Content("~/Styles/main.css")" rel="stylesheet" type="text/css" />
 

--- a/tests/syntax_test_Razor_C#.cshtml
+++ b/tests/syntax_test_Razor_C#.cshtml
@@ -62,7 +62,7 @@
 </form>
 
 <link rel="stylesheet" href="@Assets["BlazorApp.styles.css"]" />
-<div id='@MyClass.MyId' class='theclass'></div>
+<div id='@MyClass.MyId' class='theclass-@name' custom="custom-@(value)"></div>
 
 <link href="@Url.Content("~/Styles/main.css")" rel="stylesheet" type="text/css" />
 


### PR DESCRIPTION
This commit adds support for embedded inline expressions in arbitrary HTML tag attributes.